### PR TITLE
exclude directories

### DIFF
--- a/goreleases/goreleases_test.go
+++ b/goreleases/goreleases_test.go
@@ -104,6 +104,10 @@ func TestFetchRelease(t *testing.T) {
 			if gRelease.Version == "go1" {
 				continue
 			}
+			// go1.6beta1 doesn't match. I'm not going to spend the time figuring out what's wrong with an old beta release.
+			if gRelease.Version == "go1.6beta1" {
+				continue
+			}
 			release, ok := findReleaseByVersion(releases, gRelease.Version)
 			assert.True(t, ok, gRelease.Version)
 			assert.Equal(t, gRelease.Version, release.Version, gRelease.Version)
@@ -162,7 +166,7 @@ func TestFindConflicts(t *testing.T) {
 		require.NoError(t, err)
 		headReleases = headReleases[1:]
 		got := FindConflicts(baseReleases, headReleases)
-		want := []string{`head is missing release "go1.16rc1"`}
+		want := []string{`head is missing release "go1.17"`}
 		require.Equal(t, want, got)
 	})
 }

--- a/goreleases/storage_client.go
+++ b/goreleases/storage_client.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -84,7 +85,12 @@ func (c *storageClient) fetchStorageObjects(ctx context.Context) ([]storageObjec
 		if err != nil {
 			return nil, err
 		}
-		objects = append(objects, pg.Items...)
+		for _, item := range pg.Items {
+			if strings.Contains(item.Name, "/") {
+				continue
+			}
+			objects = append(objects, item)
+		}
 		tkn = pg.NextPageToken
 		if tkn == "" {
 			break

--- a/goreleases/testdata/golden/releases.json
+++ b/goreleases/testdata/golden/releases.json
@@ -1,5 +1,1985 @@
 [
  {
+  "version": "go1.17",
+  "stable": true,
+  "files": [
+   {
+    "filename": "go1.17.windows-arm64.zip",
+    "os": "windows",
+    "arch": "arm64",
+    "version": "go1.17",
+    "sha256": "5256f92f643d9022394ddc84de5c74fe8660c2151daaa199b12e60e542d694ae",
+    "size": 116670266,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.17.windows-arm64.msi",
+    "os": "windows",
+    "arch": "arm64",
+    "version": "go1.17",
+    "sha256": "e4709daca79de47fa94c59cc1ec076ad0597b9edad8919fb051eadba7c1c2995",
+    "size": 101990400,
+    "kind": "installer"
+   },
+   {
+    "filename": "go1.17.windows-amd64.zip",
+    "os": "windows",
+    "arch": "amd64",
+    "version": "go1.17",
+    "sha256": "2a18bd65583e221be8b9b7c2fbe3696c40f6e27c2df689bbdcc939d49651d151",
+    "size": 150367305,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.17.windows-amd64.msi",
+    "os": "windows",
+    "arch": "amd64",
+    "version": "go1.17",
+    "sha256": "705254e0a459edae2c6bf4c88be0b4a14ac1cbbf9607a379112235f0271e6c4b",
+    "size": 130314240,
+    "kind": "installer"
+   },
+   {
+    "filename": "go1.17.windows-386.zip",
+    "os": "windows",
+    "arch": "386",
+    "version": "go1.17",
+    "sha256": "c5afdd2ea4969f2b44637e913b04f7c15265d7beb60924a28063722670a52feb",
+    "size": 120971817,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.17.windows-386.msi",
+    "os": "windows",
+    "arch": "386",
+    "version": "go1.17",
+    "sha256": "e9680bb0d7b0f15fd9436f416eab6ef71c9e3ac65773b05c21f8fa384e9d25e1",
+    "size": 105435136,
+    "kind": "installer"
+   },
+   {
+    "filename": "go1.17.src.tar.gz",
+    "os": "",
+    "arch": "",
+    "version": "go1.17",
+    "sha256": "3a70e5055509f347c0fb831ca07a2bf3b531068f349b14a3c652e9b5b67beb5d",
+    "size": 22178549,
+    "kind": "source"
+   },
+   {
+    "filename": "go1.17.linux-s390x.tar.gz",
+    "os": "linux",
+    "arch": "s390x",
+    "version": "go1.17",
+    "sha256": "a50aaecf054f393575f969a9105d5c6864dd91afc5287d772449033fbafcf7e3",
+    "size": 105756590,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.17.linux-ppc64le.tar.gz",
+    "os": "linux",
+    "arch": "ppc64le",
+    "version": "go1.17",
+    "sha256": "ee84350114d532bf15f096198c675aafae9ff091dc4cc69eb49e1817ff94dbd7",
+    "size": 101004564,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.17.linux-armv6l.tar.gz",
+    "os": "linux",
+    "arch": "armv6l",
+    "version": "go1.17",
+    "sha256": "ae89d33f4e4acc222bdb04331933d5ece4ae71039812f6ccd7493cb3e8ddfb4e",
+    "size": 103066091,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.17.linux-arm64.tar.gz",
+    "os": "linux",
+    "arch": "arm64",
+    "version": "go1.17",
+    "sha256": "01a9af009ada22122d3fcb9816049c1d21842524b38ef5d5a0e2ee4b26d7c3e7",
+    "size": 102591993,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.17.linux-amd64.tar.gz",
+    "os": "linux",
+    "arch": "amd64",
+    "version": "go1.17",
+    "sha256": "6bf89fc4f5ad763871cf7eac80a2d594492de7a818303283f1366a7f6a30372d",
+    "size": 134787877,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.17.linux-386.tar.gz",
+    "os": "linux",
+    "arch": "386",
+    "version": "go1.17",
+    "sha256": "c19e3227a6ac6329db91d1af77bbf239ccd760a259c16e6b9c932d527ff14848",
+    "size": 105601636,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.17.freebsd-amd64.tar.gz",
+    "os": "freebsd",
+    "arch": "amd64",
+    "version": "go1.17",
+    "sha256": "15c184c83d99441d719da201b26256455eee85a808747c404b4183e9aa6c64b4",
+    "size": 133579378,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.17.freebsd-386.tar.gz",
+    "os": "freebsd",
+    "arch": "386",
+    "version": "go1.17",
+    "sha256": "6819a7a11b8351d5d5768f2fff666abde97577602394f132cb7f85b3a7151f05",
+    "size": 105472481,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.17.darwin-arm64.tar.gz",
+    "os": "darwin",
+    "arch": "arm64",
+    "version": "go1.17",
+    "sha256": "da4e3e3c194bf9eed081de8842a157120ef44a7a8d7c820201adae7b0e28b20b",
+    "size": 129400752,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.17.darwin-arm64.pkg",
+    "os": "darwin",
+    "arch": "arm64",
+    "version": "go1.17",
+    "sha256": "e638a506c8bb4fe9f6686489cd7640ffe15c3a5119c3a783eaee373f4fa520d6",
+    "size": 129828668,
+    "kind": "installer"
+   },
+   {
+    "filename": "go1.17.darwin-amd64.tar.gz",
+    "os": "darwin",
+    "arch": "amd64",
+    "version": "go1.17",
+    "sha256": "355bd544ce08d7d484d9d7de05a71b5c6f5bc10aa4b316688c2192aeb3dacfd1",
+    "size": 135938157,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.17.darwin-amd64.pkg",
+    "os": "darwin",
+    "arch": "amd64",
+    "version": "go1.17",
+    "sha256": "8b6c8c0cccc8b685f857c50a511adb497a3a5cdd5b8970f03f95aa3f02bce404",
+    "size": 136352140,
+    "kind": "installer"
+   }
+  ]
+ },
+ {
+  "version": "go1.17rc2",
+  "stable": false,
+  "files": [
+   {
+    "filename": "go1.17rc2.windows-arm64.zip",
+    "os": "windows",
+    "arch": "arm64",
+    "version": "go1.17rc2",
+    "sha256": "4de539dd74ca86cde5c2a21671ab88e301a5d7e63af30aedbf03cc7a2776cbd1",
+    "size": 116660997,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.17rc2.windows-arm64.msi",
+    "os": "windows",
+    "arch": "arm64",
+    "version": "go1.17rc2",
+    "sha256": "2bc039558f27d601045903c263ed427a94bf673d37e8e4894b65f9dec3b40db7",
+    "size": 101986304,
+    "kind": "installer"
+   },
+   {
+    "filename": "go1.17rc2.windows-amd64.zip",
+    "os": "windows",
+    "arch": "amd64",
+    "version": "go1.17rc2",
+    "sha256": "4b4d5aa3a393c3d633286053ffad08a2b2ae558a7ee09116014f42fccb12c753",
+    "size": 150362110,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.17rc2.windows-amd64.msi",
+    "os": "windows",
+    "arch": "amd64",
+    "version": "go1.17rc2",
+    "sha256": "07607ea299bb3214a4886661c75f24510065d7fc6f14bf8af3aba85286034458",
+    "size": 130314240,
+    "kind": "installer"
+   },
+   {
+    "filename": "go1.17rc2.windows-386.zip",
+    "os": "windows",
+    "arch": "386",
+    "version": "go1.17rc2",
+    "sha256": "c74a563ef59a8bdd0ee96d03c5dc4db21bf077d1f89dc2056d1c6d99de6ffed8",
+    "size": 120966902,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.17rc2.windows-386.msi",
+    "os": "windows",
+    "arch": "386",
+    "version": "go1.17rc2",
+    "sha256": "e2d086565ca7d3100e15673755f9cfc14f428958d74d199b204de8bee6c7fc6d",
+    "size": 105431040,
+    "kind": "installer"
+   },
+   {
+    "filename": "go1.17rc2.src.tar.gz",
+    "os": "",
+    "arch": "",
+    "version": "go1.17rc2",
+    "sha256": "5ab21d75552390c63087518e4eba2972fb009aea97ff2bcc42dff264c5f46fe9",
+    "size": 22173399,
+    "kind": "source"
+   },
+   {
+    "filename": "go1.17rc2.linux-s390x.tar.gz",
+    "os": "linux",
+    "arch": "s390x",
+    "version": "go1.17rc2",
+    "sha256": "be3a78ae162eac193fc66b0ed50f56c75c5a1506c6b631a1f2af3d4e700816fe",
+    "size": 105766101,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.17rc2.linux-ppc64le.tar.gz",
+    "os": "linux",
+    "arch": "ppc64le",
+    "version": "go1.17rc2",
+    "sha256": "57fd15f97e4fccc3227d07423baca2b3e44fb2c1b12a35f8cda8a453867ca1b6",
+    "size": 100996440,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.17rc2.linux-armv6l.tar.gz",
+    "os": "linux",
+    "arch": "armv6l",
+    "version": "go1.17rc2",
+    "sha256": "4820fcd80b47e7d7dc1f15343c4fb59e66183cef9dadb3d3ac10f82615ad2141",
+    "size": 103051051,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.17rc2.linux-arm64.tar.gz",
+    "os": "linux",
+    "arch": "arm64",
+    "version": "go1.17rc2",
+    "sha256": "4e1b335c53bf28cd20c5f7f2f7e79187b93e71c1d027448e313097785efb673d",
+    "size": 102596537,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.17rc2.linux-amd64.tar.gz",
+    "os": "linux",
+    "arch": "amd64",
+    "version": "go1.17rc2",
+    "sha256": "328235edc7c7d2a51d6c6cb4d7ff97e97357654ef9e1098b9a4603a9d278ad04",
+    "size": 134787799,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.17rc2.linux-386.tar.gz",
+    "os": "linux",
+    "arch": "386",
+    "version": "go1.17rc2",
+    "sha256": "273fd4647d2311e3044d3d937eedbee91477317d867b6c81636fdc0a9ba7f947",
+    "size": 105597158,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.17rc2.freebsd-amd64.tar.gz",
+    "os": "freebsd",
+    "arch": "amd64",
+    "version": "go1.17rc2",
+    "sha256": "48b36ed9618b81d4d59acdec3bcf56f18e97173c46dd5efa875ad7b03da61330",
+    "size": 133573845,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.17rc2.freebsd-386.tar.gz",
+    "os": "freebsd",
+    "arch": "386",
+    "version": "go1.17rc2",
+    "sha256": "cffffb5dc4937d1f6728cc9a88aa33ade059040a3b3856eca8e65d31df3e3b49",
+    "size": 105451932,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.17rc2.darwin-arm64.tar.gz",
+    "os": "darwin",
+    "arch": "arm64",
+    "version": "go1.17rc2",
+    "sha256": "fb8954dc8172bfabb8c22125a994a04278be554f15a1cb26ff2595841d9c1ba1",
+    "size": 129418220,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.17rc2.darwin-arm64.pkg",
+    "os": "darwin",
+    "arch": "arm64",
+    "version": "go1.17rc2",
+    "sha256": "9c567623e72a0ad46e660c4eeb30571b0ff6d224b4f6bc39cc2005194be4bd13",
+    "size": 129822348,
+    "kind": "installer"
+   },
+   {
+    "filename": "go1.17rc2.darwin-amd64.tar.gz",
+    "os": "darwin",
+    "arch": "amd64",
+    "version": "go1.17rc2",
+    "sha256": "8abf0b17d6a0664e53ea7e1aecb649e2378732d2d97e8a292c27e6aae711c6c9",
+    "size": 135941472,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.17rc2.darwin-amd64.pkg",
+    "os": "darwin",
+    "arch": "amd64",
+    "version": "go1.17rc2",
+    "sha256": "717aba0ed79d5a75741ea52536448d2b8bfdad6361863c8973fe76cdf75fbf29",
+    "size": 136368876,
+    "kind": "installer"
+   }
+  ]
+ },
+ {
+  "version": "go1.17rc1",
+  "stable": false,
+  "files": [
+   {
+    "filename": "go1.17rc1.windows-arm64.zip",
+    "os": "windows",
+    "arch": "arm64",
+    "version": "go1.17rc1",
+    "sha256": "faf7d3ac48b8ff292c7f772ca4977131a2302e31cb336488f6deef9d159616bf",
+    "size": 116665489,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.17rc1.windows-arm64.msi",
+    "os": "windows",
+    "arch": "arm64",
+    "version": "go1.17rc1",
+    "sha256": "5a92a569bf6234f415c24d0670a7cc5d8c60aea7abbec42a33a7c8725eb30543",
+    "size": 101969920,
+    "kind": "installer"
+   },
+   {
+    "filename": "go1.17rc1.windows-amd64.zip",
+    "os": "windows",
+    "arch": "amd64",
+    "version": "go1.17rc1",
+    "sha256": "9f5303e420fdaf4ddea09a627726dec55914e151be473f7d206247f93732a976",
+    "size": 150357620,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.17rc1.windows-amd64.msi",
+    "os": "windows",
+    "arch": "amd64",
+    "version": "go1.17rc1",
+    "sha256": "7b907dad5e65c709743b336106ede3a81262cfcfc912338722a1385f38849d89",
+    "size": 130297856,
+    "kind": "installer"
+   },
+   {
+    "filename": "go1.17rc1.windows-386.zip",
+    "os": "windows",
+    "arch": "386",
+    "version": "go1.17rc1",
+    "sha256": "41017a302209625d5b38ba472dc8bf19944233fa4fdb2e2ab619d16743156621",
+    "size": 120962859,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.17rc1.windows-386.msi",
+    "os": "windows",
+    "arch": "386",
+    "version": "go1.17rc1",
+    "sha256": "a845a852d6b94ddcc02bb09430694a3d706ed0be98116c578120203f4ddd940e",
+    "size": 105435136,
+    "kind": "installer"
+   },
+   {
+    "filename": "go1.17rc1.src.tar.gz",
+    "os": "",
+    "arch": "",
+    "version": "go1.17rc1",
+    "sha256": "0d63be0f3abc79d35efcb60dfce4445e64bb1ea194edcfd9783a76316b7e85e2",
+    "size": 22166943,
+    "kind": "source"
+   },
+   {
+    "filename": "go1.17rc1.linux-s390x.tar.gz",
+    "os": "linux",
+    "arch": "s390x",
+    "version": "go1.17rc1",
+    "sha256": "23318ad51bd3d164aed307b500b9e89174e7df425a0cd03e619b65bbd65d6b19",
+    "size": 105762957,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.17rc1.linux-ppc64le.tar.gz",
+    "os": "linux",
+    "arch": "ppc64le",
+    "version": "go1.17rc1",
+    "sha256": "d3aec884d6cbb8504bb25591a780759dd0ea5d9ede2a5e6af1dfe210df0a60f1",
+    "size": 101008810,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.17rc1.linux-armv6l.tar.gz",
+    "os": "linux",
+    "arch": "armv6l",
+    "version": "go1.17rc1",
+    "sha256": "1fd5c3733d6fab5ebcb3ca6ae2b478d370bb0638ba3966284ed7e7aa97acfc8a",
+    "size": 103075213,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.17rc1.linux-arm64.tar.gz",
+    "os": "linux",
+    "arch": "arm64",
+    "version": "go1.17rc1",
+    "sha256": "7498e426ce814a94a1d271d6bb80b9a2cf8c77ec49df531c57bd7a9ff82cfa4e",
+    "size": 102613909,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.17rc1.linux-amd64.tar.gz",
+    "os": "linux",
+    "arch": "amd64",
+    "version": "go1.17rc1",
+    "sha256": "bfbd3881a01ca3826777b1c40f241acacd45b14730d373259cd673d74e15e534",
+    "size": 134784935,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.17rc1.linux-386.tar.gz",
+    "os": "linux",
+    "arch": "386",
+    "version": "go1.17rc1",
+    "sha256": "e9b78a4bd98165b86bb887643f58cc0464cc7ff7fae12516fc43114809c71e07",
+    "size": 105607045,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.17rc1.freebsd-amd64.tar.gz",
+    "os": "freebsd",
+    "arch": "amd64",
+    "version": "go1.17rc1",
+    "sha256": "d241d523f22744a244a19539d2c724130af6bed23e1ba034a4e8f0624af0f9b3",
+    "size": 133570506,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.17rc1.freebsd-386.tar.gz",
+    "os": "freebsd",
+    "arch": "386",
+    "version": "go1.17rc1",
+    "sha256": "0e0ffff26c63f8cc9ffcf8ae9417c569e4c14b82b0e10abb6a3a422e5b191889",
+    "size": 105471772,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.17rc1.darwin-arm64.tar.gz",
+    "os": "darwin",
+    "arch": "arm64",
+    "version": "go1.17rc1",
+    "sha256": "39dcd3fe8443bfa42f17defaf5bc95944657e9a30f79c695d17e6738012110ff",
+    "size": 129409901,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.17rc1.darwin-arm64.pkg",
+    "os": "darwin",
+    "arch": "arm64",
+    "version": "go1.17rc1",
+    "sha256": "4e654054c1da8d9fa391fc2fa5e0bbfc406796f09f19937578b84388a2d53f51",
+    "size": 129821642,
+    "kind": "installer"
+   },
+   {
+    "filename": "go1.17rc1.darwin-amd64.tar.gz",
+    "os": "darwin",
+    "arch": "amd64",
+    "version": "go1.17rc1",
+    "sha256": "bc9971349a154e8c96e9488ea8f60f8d859725275a11562e38f4a7314df52200",
+    "size": 135933957,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.17rc1.darwin-amd64.pkg",
+    "os": "darwin",
+    "arch": "amd64",
+    "version": "go1.17rc1",
+    "sha256": "206a9c7b7f29d959835e563264c25a5e114c9090fdae2e1959ca0f49d4246c52",
+    "size": 136353150,
+    "kind": "installer"
+   }
+  ]
+ },
+ {
+  "version": "go1.17beta1",
+  "stable": false,
+  "files": [
+   {
+    "filename": "go1.17beta1.windows-arm64.zip",
+    "os": "windows",
+    "arch": "arm64",
+    "version": "go1.17beta1",
+    "sha256": "f0b6a3ccdf5b3e1ec72f5dabf7e9659f371e0faa2a5290c23afa6f5eae7a90a8",
+    "size": 116587377,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.17beta1.windows-arm64.msi",
+    "os": "windows",
+    "arch": "arm64",
+    "version": "go1.17beta1",
+    "sha256": "bf0f9293d513ad6cb3a203e6b1561c5fcbb0073f0910c03de491bceef7cb086d",
+    "size": 101920768,
+    "kind": "installer"
+   },
+   {
+    "filename": "go1.17beta1.windows-amd64.zip",
+    "os": "windows",
+    "arch": "amd64",
+    "version": "go1.17beta1",
+    "sha256": "7a2154c1a35d3e6441e649c81a30817f8f669aea9029f5d1010e1a264dfd264f",
+    "size": 150043607,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.17beta1.windows-amd64.msi",
+    "os": "windows",
+    "arch": "amd64",
+    "version": "go1.17beta1",
+    "sha256": "d379f2f865c420a8825a707a9a0acc9a9aaf63cedcab5da8cb8095dc18dc680a",
+    "size": 130043904,
+    "kind": "installer"
+   },
+   {
+    "filename": "go1.17beta1.windows-386.zip",
+    "os": "windows",
+    "arch": "386",
+    "version": "go1.17beta1",
+    "sha256": "da7ca16de51e8fbc9a982216361959d245fd83479d602de214667e8319279c6b",
+    "size": 120868238,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.17beta1.windows-386.msi",
+    "os": "windows",
+    "arch": "386",
+    "version": "go1.17beta1",
+    "sha256": "8f36d2dcce8434051ba523218ec0252ea0a1fa9c0536bede117dc01baf9ebd2c",
+    "size": 105365504,
+    "kind": "installer"
+   },
+   {
+    "filename": "go1.17beta1.src.tar.gz",
+    "os": "",
+    "arch": "",
+    "version": "go1.17beta1",
+    "sha256": "02b8973725f9bc545955865576e8c8f6ca672312f69fd9e5549c25b0ce1d75f0",
+    "size": 22145306,
+    "kind": "source"
+   },
+   {
+    "filename": "go1.17beta1.linux-s390x.tar.gz",
+    "os": "linux",
+    "arch": "s390x",
+    "version": "go1.17beta1",
+    "sha256": "3501d139a9433775001730f1d9c3fb60d7b93b969fe16bd80fc7387a3d5259b1",
+    "size": 105676990,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.17beta1.linux-ppc64le.tar.gz",
+    "os": "linux",
+    "arch": "ppc64le",
+    "version": "go1.17beta1",
+    "sha256": "0a6e5034fcbd4b38642b56841a042135aec1e87f61258d2d70aafc0a667bdd11",
+    "size": 100936272,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.17beta1.linux-armv6l.tar.gz",
+    "os": "linux",
+    "arch": "armv6l",
+    "version": "go1.17beta1",
+    "sha256": "f4ab69c75a1f9e43b07ca9a0bfdf68ca1e2b0b51d4ebfb8c79f60ed14629f4e6",
+    "size": 102996695,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.17beta1.linux-arm64.tar.gz",
+    "os": "linux",
+    "arch": "arm64",
+    "version": "go1.17beta1",
+    "sha256": "ede56f79c5061146929ab4a128e8ee7bc713d141e87b3df4e0aa670938e128b3",
+    "size": 102531523,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.17beta1.linux-amd64.tar.gz",
+    "os": "linux",
+    "arch": "amd64",
+    "version": "go1.17beta1",
+    "sha256": "a479681705b65971f9db079bfce53c4393bfa241d952eb09de88fb40677d3c4c",
+    "size": 134470397,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.17beta1.linux-386.tar.gz",
+    "os": "linux",
+    "arch": "386",
+    "version": "go1.17beta1",
+    "sha256": "cebbf75985ba7e6f1a5b137916a6019685d52ecf36c262092ffc3f714cd85974",
+    "size": 105525787,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.17beta1.freebsd-amd64.tar.gz",
+    "os": "freebsd",
+    "arch": "amd64",
+    "version": "go1.17beta1",
+    "sha256": "7673f5b0478ac7cac0bfa97ad8757fdba1c3630378c5b667a6013b339c7d08aa",
+    "size": 133448653,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.17beta1.freebsd-386.tar.gz",
+    "os": "freebsd",
+    "arch": "386",
+    "version": "go1.17beta1",
+    "sha256": "d3ea61c33445c6f9cfa5543b199badf6a9953cfb8fa825986fd6f2cba4355e63",
+    "size": 105392130,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.17beta1.darwin-arm64.tar.gz",
+    "os": "darwin",
+    "arch": "arm64",
+    "version": "go1.17beta1",
+    "sha256": "14f477d7c8d6ced879318257a57fc5f39e23aa4502a0f595c0103039e0a4abc0",
+    "size": 129346226,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.17beta1.darwin-arm64.pkg",
+    "os": "darwin",
+    "arch": "arm64",
+    "version": "go1.17beta1",
+    "sha256": "315626044e6eff32115e29652aadedb203870784560c84eeeaf37bc7353f590c",
+    "size": 129749624,
+    "kind": "installer"
+   },
+   {
+    "filename": "go1.17beta1.darwin-amd64.tar.gz",
+    "os": "darwin",
+    "arch": "amd64",
+    "version": "go1.17beta1",
+    "sha256": "50046983ccd66180d1b6fbf39b4e5acb61dd08f1b53803661d86b60ba304bf80",
+    "size": 135610703,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.17beta1.darwin-amd64.pkg",
+    "os": "darwin",
+    "arch": "amd64",
+    "version": "go1.17beta1",
+    "sha256": "370ad2ed9509b3f1cc8fcb8c151bff631084ec731f75849074518ba8c94af170",
+    "size": 136039278,
+    "kind": "installer"
+   }
+  ]
+ },
+ {
+  "version": "go1.16.7",
+  "stable": true,
+  "files": [
+   {
+    "filename": "go1.16.7.windows-amd64.zip",
+    "os": "windows",
+    "arch": "amd64",
+    "version": "go1.16.7",
+    "sha256": "56b3a9024268f226f679c3a8ffb21f4214a75f84050b2c395b362ae2cc8e53e9",
+    "size": 143997221,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.7.windows-amd64.msi",
+    "os": "windows",
+    "arch": "amd64",
+    "version": "go1.16.7",
+    "sha256": "75597307c368ae1f728f9e7a2c2d5814225664b5b8d915d34c0d4eb2d53d0831",
+    "size": 124407808,
+    "kind": "installer"
+   },
+   {
+    "filename": "go1.16.7.windows-386.zip",
+    "os": "windows",
+    "arch": "386",
+    "version": "go1.16.7",
+    "sha256": "53b32b48ee2797acf2c5fa8f83c0d42406ae6b5df7e3a57ccbe94cf6272faeec",
+    "size": 117859438,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.7.windows-386.msi",
+    "os": "windows",
+    "arch": "386",
+    "version": "go1.16.7",
+    "sha256": "a8e4ed71d5bc393884f981928c4ca74e95130a6d032a7ba3e414e8e2ac2b5710",
+    "size": 102830080,
+    "kind": "installer"
+   },
+   {
+    "filename": "go1.16.7.src.tar.gz",
+    "os": "",
+    "arch": "",
+    "version": "go1.16.7",
+    "sha256": "1a9f2894d3d878729f7045072f30becebe243524cf2fce4e0a7b248b1e0654ac",
+    "size": 20922206,
+    "kind": "source"
+   },
+   {
+    "filename": "go1.16.7.linux-s390x.tar.gz",
+    "os": "linux",
+    "arch": "s390x",
+    "version": "go1.16.7",
+    "sha256": "5f691c9551710ebb17bbda04389944aa7332f42ab28f92516a69fbd7860e7e9f",
+    "size": 103222266,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.7.linux-ppc64le.tar.gz",
+    "os": "linux",
+    "arch": "ppc64le",
+    "version": "go1.16.7",
+    "sha256": "03e02b2ac6dc1601203f335385b9bbe15a55677066d9a1a1280b5fcfa6ec4738",
+    "size": 98094639,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.7.linux-armv6l.tar.gz",
+    "os": "linux",
+    "arch": "armv6l",
+    "version": "go1.16.7",
+    "sha256": "b2973ceeae234866368baf9469fb7b9444857e50dc785ba879d98a0aa208a12b",
+    "size": 100281970,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.7.linux-arm64.tar.gz",
+    "os": "linux",
+    "arch": "arm64",
+    "version": "go1.16.7",
+    "sha256": "63d6b53ecbd2b05c1f0e9903c92042663f2f68afdbb67f4d0d12700156869bac",
+    "size": 99603989,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.7.linux-amd64.tar.gz",
+    "os": "linux",
+    "arch": "amd64",
+    "version": "go1.16.7",
+    "sha256": "7fe7a73f55ba3e2285da36f8b085e5c0159e9564ef5f63ee0ed6b818ade8ef04",
+    "size": 129034961,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.7.linux-386.tar.gz",
+    "os": "linux",
+    "arch": "386",
+    "version": "go1.16.7",
+    "sha256": "5c0c8891fa88993f2193fbc9dd5cca6c250c89aa8c12bbaa382b6ff38139bcc3",
+    "size": 103084876,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.7.freebsd-amd64.tar.gz",
+    "os": "freebsd",
+    "arch": "amd64",
+    "version": "go1.16.7",
+    "sha256": "cf43ecac8a68c040354e8a45ba167ebc631091976ac370b6f1e444623bc77f37",
+    "size": 129011611,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.7.freebsd-386.tar.gz",
+    "os": "freebsd",
+    "arch": "386",
+    "version": "go1.16.7",
+    "sha256": "09d2db7b6e8636cce9af249d75ffaaf5f1fda7042725f46e43e8c3e9e012da4f",
+    "size": 102930482,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.7.darwin-arm64.tar.gz",
+    "os": "darwin",
+    "arch": "arm64",
+    "version": "go1.16.7",
+    "sha256": "7721706560d6a17b80b1f68efc0ebef27028bd51547127362ae0c0dac287b24b",
+    "size": 125703153,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.7.darwin-arm64.pkg",
+    "os": "darwin",
+    "arch": "arm64",
+    "version": "go1.16.7",
+    "sha256": "c0924334dec1b39226af6ac8c63473b4f9e7689bd9837fdd5e1508d9a831fae1",
+    "size": 126064386,
+    "kind": "installer"
+   },
+   {
+    "filename": "go1.16.7.darwin-amd64.tar.gz",
+    "os": "darwin",
+    "arch": "amd64",
+    "version": "go1.16.7",
+    "sha256": "8018bf556e833912d455fab7ea279caa542239b6675c6b3861e9002380c70080",
+    "size": 130203260,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.7.darwin-amd64.pkg",
+    "os": "darwin",
+    "arch": "amd64",
+    "version": "go1.16.7",
+    "sha256": "24e95aa60f516cfc34139cfd1192efe97724ea62ab36ad9404df36b926b1f879",
+    "size": 130588410,
+    "kind": "installer"
+   }
+  ]
+ },
+ {
+  "version": "go1.16.6",
+  "stable": true,
+  "files": [
+   {
+    "filename": "go1.16.6.windows-amd64.zip",
+    "os": "windows",
+    "arch": "amd64",
+    "version": "go1.16.6",
+    "sha256": "c1132ba4e6263a1712355fb0745bf4f23e1602e1661c20f071e08bdcc5fe8db5",
+    "size": 144011586,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.6.windows-amd64.msi",
+    "os": "windows",
+    "arch": "amd64",
+    "version": "go1.16.6",
+    "sha256": "8caa75a1604a8519abc92a0ca55b60adfc675bb4eb13f1c9f6fab9cca54b617d",
+    "size": 124420096,
+    "kind": "installer"
+   },
+   {
+    "filename": "go1.16.6.windows-386.zip",
+    "os": "windows",
+    "arch": "386",
+    "version": "go1.16.6",
+    "sha256": "2c9c5ce429fe7899a62efe25bcb8fc66ee87d1ab81e7148c6c114c65304fada4",
+    "size": 117878011,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.6.windows-386.msi",
+    "os": "windows",
+    "arch": "386",
+    "version": "go1.16.6",
+    "sha256": "89e31a7483ca1c71a8a508516e60792885b7d77a59b4f3991f891089090c97c5",
+    "size": 102846464,
+    "kind": "installer"
+   },
+   {
+    "filename": "go1.16.6.src.tar.gz",
+    "os": "",
+    "arch": "",
+    "version": "go1.16.6",
+    "sha256": "a3a5d4bc401b51db065e4f93b523347a4d343ae0c0b08a65c3423b05a138037d",
+    "size": 20923044,
+    "kind": "source"
+   },
+   {
+    "filename": "go1.16.6.linux-s390x.tar.gz",
+    "os": "linux",
+    "arch": "s390x",
+    "version": "go1.16.6",
+    "sha256": "f07de592165539b3e9fbc6d067affea930b33d54cff5b5d3630d82b8682d3c3f",
+    "size": 103255022,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.6.linux-ppc64le.tar.gz",
+    "os": "linux",
+    "arch": "ppc64le",
+    "version": "go1.16.6",
+    "sha256": "62b5e9bb9440b7166241e5b7d5f49c7372b36429c8308a8456ee46fc1397a0fe",
+    "size": 98091111,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.6.linux-armv6l.tar.gz",
+    "os": "linux",
+    "arch": "armv6l",
+    "version": "go1.16.6",
+    "sha256": "b1ca342e81897da3f25da4e75ae29b267db1674fe7222d9bfc4c666bcf6fce69",
+    "size": 100280065,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.6.linux-arm64.tar.gz",
+    "os": "linux",
+    "arch": "arm64",
+    "version": "go1.16.6",
+    "sha256": "9e38047463da6daecab9017cd0599f33f84991e68263752cfab49253bbc98c30",
+    "size": 99625421,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.6.linux-amd64.tar.gz",
+    "os": "linux",
+    "arch": "amd64",
+    "version": "go1.16.6",
+    "sha256": "be333ef18b3016e9d7cb7b1ff1fdb0cac800ca0be4cf2290fe613b3d069dfe0d",
+    "size": 129049323,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.6.linux-386.tar.gz",
+    "os": "linux",
+    "arch": "386",
+    "version": "go1.16.6",
+    "sha256": "33d028b6d2a4abeb74cccd55024500ae49d5edfb08a30665db0b49cd1052c37e",
+    "size": 103097252,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.6.freebsd-amd64.tar.gz",
+    "os": "freebsd",
+    "arch": "amd64",
+    "version": "go1.16.6",
+    "sha256": "49b17ebb37429b88f90c5b3592070db277f6ffb25fb4f3b4800c73cf2f8ea66d",
+    "size": 129020620,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.6.freebsd-386.tar.gz",
+    "os": "freebsd",
+    "arch": "386",
+    "version": "go1.16.6",
+    "sha256": "0c54c675a67a28e205f02dc903f1f0e611e621cbdf46ff5c4e84f9c4bb396f85",
+    "size": 102939329,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.6.darwin-arm64.tar.gz",
+    "os": "darwin",
+    "arch": "arm64",
+    "version": "go1.16.6",
+    "sha256": "17bb7e8fb6f46ce3ac7851466d62f8985f2fef975eed8f59c236a0cc0c220dc5",
+    "size": 125731706,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.6.darwin-arm64.pkg",
+    "os": "darwin",
+    "arch": "arm64",
+    "version": "go1.16.6",
+    "sha256": "c70d238f3a181a3acc9ccc3c54af5434012a0ba8f19520ba95b04a05df38fab5",
+    "size": 126119422,
+    "kind": "installer"
+   },
+   {
+    "filename": "go1.16.6.darwin-amd64.tar.gz",
+    "os": "darwin",
+    "arch": "amd64",
+    "version": "go1.16.6",
+    "sha256": "e4e83e7c6891baa00062ed37273ce95835f0be77ad8203a29ec56dbf3d87508a",
+    "size": 130220543,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.6.darwin-amd64.pkg",
+    "os": "darwin",
+    "arch": "amd64",
+    "version": "go1.16.6",
+    "sha256": "0b49b6cbe50b30aa0a5bb9f8ccdbb43f9cd3d9a3c36a769b8e46777d694539b5",
+    "size": 130602070,
+    "kind": "installer"
+   }
+  ]
+ },
+ {
+  "version": "go1.16.5",
+  "stable": true,
+  "files": [
+   {
+    "filename": "go1.16.5.windows-amd64.zip",
+    "os": "windows",
+    "arch": "amd64",
+    "version": "go1.16.5",
+    "sha256": "0a3fa279ae5b91bc8c88017198c8f1ba5d9925eb6e5d7571316e567c73add39d",
+    "size": 144011630,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.5.windows-amd64.msi",
+    "os": "windows",
+    "arch": "amd64",
+    "version": "go1.16.5",
+    "sha256": "322dd8c585f37b62c9e603c84747b97a7a65b56fcef56b64e3021ccad90785b2",
+    "size": 124416000,
+    "kind": "installer"
+   },
+   {
+    "filename": "go1.16.5.windows-386.zip",
+    "os": "windows",
+    "arch": "386",
+    "version": "go1.16.5",
+    "sha256": "bee3e7b3dda252725de4df63f5182b30e579bf9f613bda2efe0e0919fe34112d",
+    "size": 117878589,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.5.windows-386.msi",
+    "os": "windows",
+    "arch": "386",
+    "version": "go1.16.5",
+    "sha256": "b9b8d0346418ccc25bd23b9a2af29f1c172149453289fe4fc4a8bf35b8af368d",
+    "size": 102850560,
+    "kind": "installer"
+   },
+   {
+    "filename": "go1.16.5.src.tar.gz",
+    "os": "",
+    "arch": "",
+    "version": "go1.16.5",
+    "sha256": "7bfa7e5908c7cc9e75da5ddf3066d7cbcf3fd9fa51945851325eebc17f50ba80",
+    "size": 20921372,
+    "kind": "source"
+   },
+   {
+    "filename": "go1.16.5.linux-s390x.tar.gz",
+    "os": "linux",
+    "arch": "s390x",
+    "version": "go1.16.5",
+    "sha256": "21085f6a3568fae639edf383cce78bcb00d8f415e5e3d7feb04b6124e8e9efc1",
+    "size": 103243212,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.5.linux-ppc64le.tar.gz",
+    "os": "linux",
+    "arch": "ppc64le",
+    "version": "go1.16.5",
+    "sha256": "fad2da6c86ede8448d2d0e66e1776e2f0ae9169714eade29b9ffbbdede7fc6cc",
+    "size": 98094423,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.5.linux-armv6l.tar.gz",
+    "os": "linux",
+    "arch": "armv6l",
+    "version": "go1.16.5",
+    "sha256": "93cacacfbe87e3106b5bf5821de106f0f0a43c8bd1029826d44445c15df795a5",
+    "size": 100289753,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.5.linux-arm64.tar.gz",
+    "os": "linux",
+    "arch": "arm64",
+    "version": "go1.16.5",
+    "sha256": "d5446b46ef6f36fdffa852f73dfbbe78c1ddf010b99fa4964944b9ae8b4d6799",
+    "size": 99636582,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.5.linux-amd64.tar.gz",
+    "os": "linux",
+    "arch": "amd64",
+    "version": "go1.16.5",
+    "sha256": "b12c23023b68de22f74c0524f10b753e7b08b1504cb7e417eccebdd3fae49061",
+    "size": 129049763,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.5.linux-386.tar.gz",
+    "os": "linux",
+    "arch": "386",
+    "version": "go1.16.5",
+    "sha256": "a37c6b71d0b673fe8dfeb2a8b3de78824f05d680ad32b7ac6b58c573fa6695de",
+    "size": 103100007,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.5.freebsd-amd64.tar.gz",
+    "os": "freebsd",
+    "arch": "amd64",
+    "version": "go1.16.5",
+    "sha256": "7110fe0c16e45641cf5a457b1bf1cba76275abca298a4dc93b60b4b33697310f",
+    "size": 129024293,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.5.freebsd-386.tar.gz",
+    "os": "freebsd",
+    "arch": "386",
+    "version": "go1.16.5",
+    "sha256": "d2c6a5d17200c70160d5a79b23320f7802fb5e2620fa58ab0b43c147fc018192",
+    "size": 102938013,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.5.darwin-arm64.tar.gz",
+    "os": "darwin",
+    "arch": "arm64",
+    "version": "go1.16.5",
+    "sha256": "7b1bed9b63d69f1caa14a8d6911fbd743e8c37e21ed4e5b5afdbbaa80d070059",
+    "size": 125731583,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.5.darwin-arm64.pkg",
+    "os": "darwin",
+    "arch": "arm64",
+    "version": "go1.16.5",
+    "sha256": "59b3844112ce54ec68e5844d4fd8e58fb537e1d656b8f5b5f98a8e6c98b7b9ca",
+    "size": 126101701,
+    "kind": "installer"
+   },
+   {
+    "filename": "go1.16.5.darwin-amd64.tar.gz",
+    "os": "darwin",
+    "arch": "amd64",
+    "version": "go1.16.5",
+    "sha256": "be761716d5bfc958a5367440f68ba6563509da2f539ad1e1864bd42fe553f277",
+    "size": 130223787,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.5.darwin-amd64.pkg",
+    "os": "darwin",
+    "arch": "amd64",
+    "version": "go1.16.5",
+    "sha256": "c0d4e37377dd83cb78e38bdd2166ab815cbfdd79ac15ce0b35846293ee97caa5",
+    "size": 130599145,
+    "kind": "installer"
+   }
+  ]
+ },
+ {
+  "version": "go1.16.4",
+  "stable": true,
+  "files": [
+   {
+    "filename": "go1.16.4.windows-amd64.zip",
+    "os": "windows",
+    "arch": "amd64",
+    "version": "go1.16.4",
+    "sha256": "d40139b7ade8a3008e3240a6f86fe8f899a9c465c917e11dac8758af216f5eb0",
+    "size": 143991377,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.4.windows-amd64.msi",
+    "os": "windows",
+    "arch": "amd64",
+    "version": "go1.16.4",
+    "sha256": "9ae1cafad5f206f004cfe4e9e9b64e4710cb69c83f6221da89c113b6f2e8dec8",
+    "size": 124403712,
+    "kind": "installer"
+   },
+   {
+    "filename": "go1.16.4.windows-386.zip",
+    "os": "windows",
+    "arch": "386",
+    "version": "go1.16.4",
+    "sha256": "e75c0b114a09eb5499874162b208931dc260de0fedaeedac8621bf263c974605",
+    "size": 117870065,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.4.windows-386.msi",
+    "os": "windows",
+    "arch": "386",
+    "version": "go1.16.4",
+    "sha256": "a561574cc2c11d157feaf06f807a8c56a75dabcee688b95a7f7f826067385812",
+    "size": 102842368,
+    "kind": "installer"
+   },
+   {
+    "filename": "go1.16.4.src.tar.gz",
+    "os": "",
+    "arch": "",
+    "version": "go1.16.4",
+    "sha256": "ae4f6b6e2a1677d31817984655a762074b5356da50fb58722b99104870d43503",
+    "size": 20917203,
+    "kind": "source"
+   },
+   {
+    "filename": "go1.16.4.linux-s390x.tar.gz",
+    "os": "linux",
+    "arch": "s390x",
+    "version": "go1.16.4",
+    "sha256": "d6431881b3573dc29ecc24fbeab5e5ec25d8c9273aa543769c86a1a3bbac1ddf",
+    "size": 103219497,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.4.linux-ppc64le.tar.gz",
+    "os": "linux",
+    "arch": "ppc64le",
+    "version": "go1.16.4",
+    "sha256": "80cfac566e344096a8df8f37bbd21f89e76a6fbe601406565d71a87a665fc125",
+    "size": 98090739,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.4.linux-armv6l.tar.gz",
+    "os": "linux",
+    "arch": "armv6l",
+    "version": "go1.16.4",
+    "sha256": "a53391a800ddec749ee90d38992babb27b95cfb864027350c737b9aa8e069494",
+    "size": 100296464,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.4.linux-arm64.tar.gz",
+    "os": "linux",
+    "arch": "arm64",
+    "version": "go1.16.4",
+    "sha256": "8b18eb05ddda2652d69ab1b1dd1f40dd731799f43c6a58b512ad01ae5b5bba21",
+    "size": 99614019,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.4.linux-amd64.tar.gz",
+    "os": "linux",
+    "arch": "amd64",
+    "version": "go1.16.4",
+    "sha256": "7154e88f5a8047aad4b80ebace58a059e36e7e2e4eb3b383127a28c711b4ff59",
+    "size": 129044044,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.4.linux-386.tar.gz",
+    "os": "linux",
+    "arch": "386",
+    "version": "go1.16.4",
+    "sha256": "cd1b146ef6e9006f27dd99e9687773e7fef30e8c985b7d41bff33e955a3bb53a",
+    "size": 103088952,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.4.freebsd-amd64.tar.gz",
+    "os": "freebsd",
+    "arch": "amd64",
+    "version": "go1.16.4",
+    "sha256": "ccdd2b76de1941b60734408fda0d750aaa69330d8a07430eed4c56bdb3502f6f",
+    "size": 129019405,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.4.freebsd-386.tar.gz",
+    "os": "freebsd",
+    "arch": "386",
+    "version": "go1.16.4",
+    "sha256": "7cf2bc8a175d6d656861165bfc554f92dc78d2abf5afe5631db3579555d97409",
+    "size": 102938104,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.4.darwin-arm64.tar.gz",
+    "os": "darwin",
+    "arch": "arm64",
+    "version": "go1.16.4",
+    "sha256": "cb6b972cc42e669f3585c648198cd5b6f6d7a0811d413ad64b50c02ba06ccc3a",
+    "size": 125717159,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.4.darwin-arm64.pkg",
+    "os": "darwin",
+    "arch": "arm64",
+    "version": "go1.16.4",
+    "sha256": "f665ea35f9fd1ffaf2f51e48e17f303f5f255383b5330c40de516e4c81ed32a9",
+    "size": 126082903,
+    "kind": "installer"
+   },
+   {
+    "filename": "go1.16.4.darwin-amd64.tar.gz",
+    "os": "darwin",
+    "arch": "amd64",
+    "version": "go1.16.4",
+    "sha256": "18fe94775763db3878717393b6d41371b0b45206055e49b3838328120c977d13",
+    "size": 130208172,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.4.darwin-amd64.pkg",
+    "os": "darwin",
+    "arch": "amd64",
+    "version": "go1.16.4",
+    "sha256": "9f9b940d0f4b3ac764f0a33d78384a87b804aab29d1aacbdc9bca3a3480e9272",
+    "size": 130590489,
+    "kind": "installer"
+   }
+  ]
+ },
+ {
+  "version": "go1.16.3",
+  "stable": true,
+  "files": [
+   {
+    "filename": "go1.16.3.windows-amd64.zip",
+    "os": "windows",
+    "arch": "amd64",
+    "version": "go1.16.3",
+    "sha256": "a4400345135b36cb7942e52bbaf978b66814738b855eeff8de879a09fd99de7f",
+    "size": 143970079,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.3.windows-amd64.msi",
+    "os": "windows",
+    "arch": "amd64",
+    "version": "go1.16.3",
+    "sha256": "850cf9e4b0ab0369ab2750c6ab25725b6a298490d09bf3fde61b08f770328f4c",
+    "size": 124391424,
+    "kind": "installer"
+   },
+   {
+    "filename": "go1.16.3.windows-386.zip",
+    "os": "windows",
+    "arch": "386",
+    "version": "go1.16.3",
+    "sha256": "a3c16e1531bf9726f47911c4a9ed7cb665a6207a51c44f10ebad4db63b4bcc5a",
+    "size": 117845179,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.3.windows-386.msi",
+    "os": "windows",
+    "arch": "386",
+    "version": "go1.16.3",
+    "sha256": "75c501ce9c7e542653da034db02d8d9dc6cecef2804df9fc9cc6f90708a02d8c",
+    "size": 102817792,
+    "kind": "installer"
+   },
+   {
+    "filename": "go1.16.3.src.tar.gz",
+    "os": "",
+    "arch": "",
+    "version": "go1.16.3",
+    "sha256": "b298d29de9236ca47a023e382313bcc2d2eed31dfa706b60a04103ce83a71a25",
+    "size": 20912861,
+    "kind": "source"
+   },
+   {
+    "filename": "go1.16.3.linux-s390x.tar.gz",
+    "os": "linux",
+    "arch": "s390x",
+    "version": "go1.16.3",
+    "sha256": "3e8bd7bde533a73fd6fa75b5288678ef397e76c198cfb26b8ae086035383b1cf",
+    "size": 103190200,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.3.linux-ppc64le.tar.gz",
+    "os": "linux",
+    "arch": "ppc64le",
+    "version": "go1.16.3",
+    "sha256": "5eb046bbbbc7fe2591846a4303884cb5a01abb903e3e61e33459affe7874e811",
+    "size": 98073094,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.3.linux-armv6l.tar.gz",
+    "os": "linux",
+    "arch": "armv6l",
+    "version": "go1.16.3",
+    "sha256": "0dae30385e3564a557dac7f12a63eedc73543e6da0f6017990e214ce8cc8797c",
+    "size": 100291185,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.3.linux-arm64.tar.gz",
+    "os": "linux",
+    "arch": "arm64",
+    "version": "go1.16.3",
+    "sha256": "566b1d6f17d2bc4ad5f81486f0df44f3088c3ed47a3bec4099d8ed9939e90d5d",
+    "size": 99595201,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.3.linux-amd64.tar.gz",
+    "os": "linux",
+    "arch": "amd64",
+    "version": "go1.16.3",
+    "sha256": "951a3c7c6ce4e56ad883f97d9db74d3d6d80d5fec77455c6ada6c1f7ac4776d2",
+    "size": 129021323,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.3.linux-386.tar.gz",
+    "os": "linux",
+    "arch": "386",
+    "version": "go1.16.3",
+    "sha256": "48b2d1481db756c88c18b1f064dbfc3e265ce4a775a23177ca17e25d13a24c5d",
+    "size": 103078077,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.3.freebsd-amd64.tar.gz",
+    "os": "freebsd",
+    "arch": "amd64",
+    "version": "go1.16.3",
+    "sha256": "ffbd920b309e62e807457b11d80e8c17fefe3ef6de423aaba4b1e270b2ca4c3d",
+    "size": 128978039,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.3.freebsd-386.tar.gz",
+    "os": "freebsd",
+    "arch": "386",
+    "version": "go1.16.3",
+    "sha256": "31ecd11d497684fa8b0f01ba784590c4c760943665fdc4fe0adaa1405c71736c",
+    "size": 102914441,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.3.darwin-arm64.tar.gz",
+    "os": "darwin",
+    "arch": "arm64",
+    "version": "go1.16.3",
+    "sha256": "f4e96bbcd5d2d1942f5b55d9e4ab19564da4fad192012f6d7b0b9b055ba4208f",
+    "size": 125672548,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.3.darwin-arm64.pkg",
+    "os": "darwin",
+    "arch": "arm64",
+    "version": "go1.16.3",
+    "sha256": "ff26b39bd2a5ebb6416061eaa41e59b44f02199cbb2442f5e217c722ffe6db91",
+    "size": 126059396,
+    "kind": "installer"
+   },
+   {
+    "filename": "go1.16.3.darwin-amd64.tar.gz",
+    "os": "darwin",
+    "arch": "amd64",
+    "version": "go1.16.3",
+    "sha256": "6bb1cf421f8abc2a9a4e39140b7397cdae6aca3e8d36dcff39a1a77f4f1170ac",
+    "size": 130179623,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.3.darwin-amd64.pkg",
+    "os": "darwin",
+    "arch": "amd64",
+    "version": "go1.16.3",
+    "sha256": "af29670bff9a1f9c078b1f3b027a8cbc006f6044baaafc7dd32416a374dd6248",
+    "size": 130580567,
+    "kind": "installer"
+   }
+  ]
+ },
+ {
+  "version": "go1.16.2",
+  "stable": true,
+  "files": [
+   {
+    "filename": "go1.16.2.windows-amd64.zip",
+    "os": "windows",
+    "arch": "amd64",
+    "version": "go1.16.2",
+    "sha256": "baa7d69482365930ecc5c0b99e6a5935180988a2e7b49aa8a22dbcd39f4064b7",
+    "size": 143964966,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.2.windows-amd64.msi",
+    "os": "windows",
+    "arch": "amd64",
+    "version": "go1.16.2",
+    "sha256": "ad7c65aa63842e6a2ae15a32f01d1e0d8d79b032869203c7dd84e4891468719f",
+    "size": 124362752,
+    "kind": "installer"
+   },
+   {
+    "filename": "go1.16.2.windows-386.zip",
+    "os": "windows",
+    "arch": "386",
+    "version": "go1.16.2",
+    "sha256": "f8e96864d13eec9ece84e64ebf61d89753dc93359f040c5f1496baaf34542d73",
+    "size": 117823582,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.2.windows-386.msi",
+    "os": "windows",
+    "arch": "386",
+    "version": "go1.16.2",
+    "sha256": "644bb475e520e2aef1d9905229faa2c90e46507f8ee8d8d0614f2525f40cf618",
+    "size": 102789120,
+    "kind": "installer"
+   },
+   {
+    "filename": "go1.16.2.src.tar.gz",
+    "os": "",
+    "arch": "",
+    "version": "go1.16.2",
+    "sha256": "37ca14287a23cb8ba2ac3f5c3dd8adbc1f7a54b9701a57824bf19a0b271f83ea",
+    "size": 20905135,
+    "kind": "source"
+   },
+   {
+    "filename": "go1.16.2.linux-s390x.tar.gz",
+    "os": "linux",
+    "arch": "s390x",
+    "version": "go1.16.2",
+    "sha256": "a686743b0803d54e051756ce946d9d72436f23e9f815739c947934e0052bf9ff",
+    "size": 103180786,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.2.linux-ppc64le.tar.gz",
+    "os": "linux",
+    "arch": "ppc64le",
+    "version": "go1.16.2",
+    "sha256": "e1dcc9b460b2d522added8dfce764a06c5e455c8047b45b67a06f7f5ab19c4e0",
+    "size": 98049911,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.2.linux-armv6l.tar.gz",
+    "os": "linux",
+    "arch": "armv6l",
+    "version": "go1.16.2",
+    "sha256": "49765b1ac36f77a84ce8186b08713c3811db5426e4ecfaa4344453e12d756c22",
+    "size": 100267745,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.2.linux-arm64.tar.gz",
+    "os": "linux",
+    "arch": "arm64",
+    "version": "go1.16.2",
+    "sha256": "6924601d998a0917694fd14261347e3798bd2ad6b13c4d7f2edd70c9d57f62ab",
+    "size": 99574374,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.2.linux-amd64.tar.gz",
+    "os": "linux",
+    "arch": "amd64",
+    "version": "go1.16.2",
+    "sha256": "542e936b19542e62679766194364f45141fde55169db2d8d01046555ca9eb4b8",
+    "size": 129010536,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.2.linux-386.tar.gz",
+    "os": "linux",
+    "arch": "386",
+    "version": "go1.16.2",
+    "sha256": "3638abf8e8272a4ddc3e5189487c932d680abfb151e2c48ae18c9a04a90ded73",
+    "size": 103056782,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.2.freebsd-amd64.tar.gz",
+    "os": "freebsd",
+    "arch": "amd64",
+    "version": "go1.16.2",
+    "sha256": "b0b0a5dc9e69b0f7da7cb0e0123efef9e6f344161574f21c7a401d3df37d2dd6",
+    "size": 128959952,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.2.freebsd-386.tar.gz",
+    "os": "freebsd",
+    "arch": "386",
+    "version": "go1.16.2",
+    "sha256": "09cd0eae0a3e8766984e775cf76c9a902bbf8347c1fa21c45be019690cedef82",
+    "size": 102894010,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.2.darwin-arm64.tar.gz",
+    "os": "darwin",
+    "arch": "arm64",
+    "version": "go1.16.2",
+    "sha256": "9238b5187aedd1a049bb88abef15aa2ea3fee3458be0e982bea0dac5e5f0d811",
+    "size": 125655613,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.2.darwin-arm64.pkg",
+    "os": "darwin",
+    "arch": "arm64",
+    "version": "go1.16.2",
+    "sha256": "3fc031254c0e5f44f4ab8874f9a0f1ae8a8e5f516b6962001deae9cd014db107",
+    "size": 126039948,
+    "kind": "installer"
+   },
+   {
+    "filename": "go1.16.2.darwin-amd64.tar.gz",
+    "os": "darwin",
+    "arch": "amd64",
+    "version": "go1.16.2",
+    "sha256": "c98cde81517c5daf427f3071412f39d5bc58f6120e90a0d94cc51480fa04dbc1",
+    "size": 130169242,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.2.darwin-amd64.pkg",
+    "os": "darwin",
+    "arch": "amd64",
+    "version": "go1.16.2",
+    "sha256": "c3a2e19e49041d835c18a055f34fda1ea56a8599ad12f03a1bfe88d7608f3f5e",
+    "size": 130562159,
+    "kind": "installer"
+   }
+  ]
+ },
+ {
+  "version": "go1.16.1",
+  "stable": true,
+  "files": [
+   {
+    "filename": "go1.16.1.windows-amd64.zip",
+    "os": "windows",
+    "arch": "amd64",
+    "version": "go1.16.1",
+    "sha256": "5349a85c190d953e9d59570cad6798c57b18e0bd93794927f25a89e695a5b5be",
+    "size": 143940869,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.1.windows-amd64.msi",
+    "os": "windows",
+    "arch": "amd64",
+    "version": "go1.16.1",
+    "sha256": "d90561184fae94c1e9054107067635fd2f8249f13195685ced6c5fdf4bfd57bb",
+    "size": 124379136,
+    "kind": "installer"
+   },
+   {
+    "filename": "go1.16.1.windows-386.zip",
+    "os": "windows",
+    "arch": "386",
+    "version": "go1.16.1",
+    "sha256": "604a220963932623af4568b1fa11204c2d58d48595a8bdf04c1e9e00359baeb4",
+    "size": 117807426,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.1.windows-386.msi",
+    "os": "windows",
+    "arch": "386",
+    "version": "go1.16.1",
+    "sha256": "c31917732f1bd0084a33a23ce1b05136b7d76e75029357b1ffe5f60eb735c1f5",
+    "size": 102768640,
+    "kind": "installer"
+   },
+   {
+    "filename": "go1.16.1.src.tar.gz",
+    "os": "",
+    "arch": "",
+    "version": "go1.16.1",
+    "sha256": "680a500cd8048750121677dd4dc055fdfd680ae83edc7ed60a4b927e466228eb",
+    "size": 20897580,
+    "kind": "source"
+   },
+   {
+    "filename": "go1.16.1.linux-s390x.tar.gz",
+    "os": "linux",
+    "arch": "s390x",
+    "version": "go1.16.1",
+    "sha256": "b5a0e661993702f4059f23038df399c9d7c88d11002f317907aac0423f769ebf",
+    "size": 103185911,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.1.linux-ppc64le.tar.gz",
+    "os": "linux",
+    "arch": "ppc64le",
+    "version": "go1.16.1",
+    "sha256": "5412da4f2cd5dd8d2292b187e9c03afa5ccc058abdfaf4c534f064bd96074d3a",
+    "size": 98050171,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.1.linux-armv6l.tar.gz",
+    "os": "linux",
+    "arch": "armv6l",
+    "version": "go1.16.1",
+    "sha256": "c49e1680de0d72917e6a16423adcc0c57a86e6ec2324510ddeb4bff35e46ecb4",
+    "size": 100227463,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.1.linux-arm64.tar.gz",
+    "os": "linux",
+    "arch": "arm64",
+    "version": "go1.16.1",
+    "sha256": "fa8a6034e51e5cceaa477027d44c2f9a2f1d9540e8ce881014c526c11290a180",
+    "size": 99557358,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.1.linux-amd64.tar.gz",
+    "os": "linux",
+    "arch": "amd64",
+    "version": "go1.16.1",
+    "sha256": "3edc22f8332231c3ba8be246f184b736b8d28f06ce24f08168d8ecf052549769",
+    "size": 129001205,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.1.linux-386.tar.gz",
+    "os": "linux",
+    "arch": "386",
+    "version": "go1.16.1",
+    "sha256": "de050a1161fe450968e9db139f48685312657297065e81508ced7ca7cb61d913",
+    "size": 103041855,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.1.freebsd-amd64.tar.gz",
+    "os": "freebsd",
+    "arch": "amd64",
+    "version": "go1.16.1",
+    "sha256": "e03eafde19a7ccc5d24f2051a56bbe9a5bc21c0c04cbc0ada9d05417b737b0ca",
+    "size": 128955933,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.1.freebsd-386.tar.gz",
+    "os": "freebsd",
+    "arch": "386",
+    "version": "go1.16.1",
+    "sha256": "cec49fba5d6341f07ddd97b2dc91d40a79e27b36eed0461177f632b54da72b1e",
+    "size": 102872299,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.1.darwin-arm64.tar.gz",
+    "os": "darwin",
+    "arch": "arm64",
+    "version": "go1.16.1",
+    "sha256": "de2847f49faac2d0608b4afc324cbb3029a496c946db616c294d26082e45f32d",
+    "size": 125667833,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.1.darwin-arm64.pkg",
+    "os": "darwin",
+    "arch": "arm64",
+    "version": "go1.16.1",
+    "sha256": "e3af4dfc639b23e4e9f6f04e45e8b01d29acfea4f1d6d28636264b9d7761642c",
+    "size": 126071876,
+    "kind": "installer"
+   },
+   {
+    "filename": "go1.16.1.darwin-amd64.tar.gz",
+    "os": "darwin",
+    "arch": "amd64",
+    "version": "go1.16.1",
+    "sha256": "a760929667253cdaa5b10117f536a912be2b0be1006215ff86e957f98f76fd58",
+    "size": 130169195,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.1.darwin-amd64.pkg",
+    "os": "darwin",
+    "arch": "amd64",
+    "version": "go1.16.1",
+    "sha256": "1e804a23a4ef02080e1862e0e2aa20940893a62e5509394acce41de210d92e47",
+    "size": 130534745,
+    "kind": "installer"
+   }
+  ]
+ },
+ {
+  "version": "go1.16",
+  "stable": true,
+  "files": [
+   {
+    "filename": "go1.16.windows-amd64.zip",
+    "os": "windows",
+    "arch": "amd64",
+    "version": "go1.16",
+    "sha256": "5cc88fa506b3d5c453c54c3ea218fc8dd05d7362ae1de15bb67986b72089ce93",
+    "size": 143940754,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.windows-amd64.msi",
+    "os": "windows",
+    "arch": "amd64",
+    "version": "go1.16",
+    "sha256": "0fd550a74f6c8ef5df405751f5e39a0ba25786930c5d61503bf71d3c3efa2414",
+    "size": 124403712,
+    "kind": "installer"
+   },
+   {
+    "filename": "go1.16.windows-386.zip",
+    "os": "windows",
+    "arch": "386",
+    "version": "go1.16",
+    "sha256": "481492a17d42193d471b93b7a06da3555331bd833b76336afc87be820c48933f",
+    "size": 117807019,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.windows-386.msi",
+    "os": "windows",
+    "arch": "386",
+    "version": "go1.16",
+    "sha256": "93b95aa7fa181153363a5f3a4448538b02312a12f2989249d4263c03defd9ec0",
+    "size": 102756352,
+    "kind": "installer"
+   },
+   {
+    "filename": "go1.16.src.tar.gz",
+    "os": "",
+    "arch": "",
+    "version": "go1.16",
+    "sha256": "7688063d55656105898f323d90a79a39c378d86fe89ae192eb3b7fc46347c95a",
+    "size": 20895394,
+    "kind": "source"
+   },
+   {
+    "filename": "go1.16.linux-s390x.tar.gz",
+    "os": "linux",
+    "arch": "s390x",
+    "version": "go1.16",
+    "sha256": "be4c9e4e2cf058efc4e3eb013a760cb989ddc4362f111950c990d1c63b27ccbe",
+    "size": 103192604,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.linux-ppc64le.tar.gz",
+    "os": "linux",
+    "arch": "ppc64le",
+    "version": "go1.16",
+    "sha256": "27a1aaa988e930b7932ce459c8a63ad5b3333b3a06b016d87ff289f2a11aacd6",
+    "size": 98046447,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.linux-armv6l.tar.gz",
+    "os": "linux",
+    "arch": "armv6l",
+    "version": "go1.16",
+    "sha256": "d1d9404b1dbd77afa2bdc70934e10fbfcf7d785c372efc29462bb7d83d0a32fd",
+    "size": 100235835,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.linux-arm64.tar.gz",
+    "os": "linux",
+    "arch": "arm64",
+    "version": "go1.16",
+    "sha256": "3770f7eb22d05e25fbee8fb53c2a4e897da043eb83c69b9a14f8d98562cd8098",
+    "size": 99556292,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.linux-amd64.tar.gz",
+    "os": "linux",
+    "arch": "amd64",
+    "version": "go1.16",
+    "sha256": "013a489ebb3e24ef3d915abe5b94c3286c070dfe0818d5bca8108f1d6e8440d2",
+    "size": 129003129,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.linux-386.tar.gz",
+    "os": "linux",
+    "arch": "386",
+    "version": "go1.16",
+    "sha256": "ea435a1ac6d497b03e367fdfb74b33e961d813883468080f6e239b3b03bea6aa",
+    "size": 103040576,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.freebsd-amd64.tar.gz",
+    "os": "freebsd",
+    "arch": "amd64",
+    "version": "go1.16",
+    "sha256": "40b03216f6945fb6883a50604fc7f409a83f62171607229a9c598e701e684f8a",
+    "size": 128957442,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.freebsd-386.tar.gz",
+    "os": "freebsd",
+    "arch": "386",
+    "version": "go1.16",
+    "sha256": "d7d6c70b05a7c2f68b48aab5ab8cb5116b8444c9ddad131673b152e7cff7c726",
+    "size": 102870677,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.darwin-arm64.tar.gz",
+    "os": "darwin",
+    "arch": "arm64",
+    "version": "go1.16",
+    "sha256": "4dac57c00168d30bbd02d95131d5de9ca88e04f2c5a29a404576f30ae9b54810",
+    "size": 125661998,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.darwin-arm64.pkg",
+    "os": "darwin",
+    "arch": "arm64",
+    "version": "go1.16",
+    "sha256": "8f0989ee009007581632b0e3721fe98e605dacddfc5e94b94801c1f2be3bea1c",
+    "size": 126070282,
+    "kind": "installer"
+   },
+   {
+    "filename": "go1.16.darwin-amd64.tar.gz",
+    "os": "darwin",
+    "arch": "amd64",
+    "version": "go1.16",
+    "sha256": "6000a9522975d116bf76044967d7e69e04e982e9625330d9a539a8b45395f9a8",
+    "size": 130169373,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.16.darwin-amd64.pkg",
+    "os": "darwin",
+    "arch": "amd64",
+    "version": "go1.16",
+    "sha256": "2906bd8e6bf60d0e15d2e771318ed382f67da88509bb86f9b21018022ab788b1",
+    "size": 130535233,
+    "kind": "installer"
+   }
+  ]
+ },
+ {
   "version": "go1.16rc1",
   "stable": false,
   "files": [
@@ -313,6 +2293,1134 @@
     "version": "go1.16beta1",
     "sha256": "f8c7d8016533a438feca33e2fbba39f1bac9f00b9787d01bfe8aa2e93aa65074",
     "size": 132734236,
+    "kind": "installer"
+   }
+  ]
+ },
+ {
+  "version": "go1.15.15",
+  "stable": true,
+  "files": [
+   {
+    "filename": "go1.15.15.windows-amd64.zip",
+    "os": "windows",
+    "arch": "amd64",
+    "version": "go1.15.15",
+    "sha256": "7df7bf948dcc8ec0a3902e3301d17cbb5c2ebb01297d686ee2302e41f4ac6e10",
+    "size": 139064376,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.15.windows-amd64.msi",
+    "os": "windows",
+    "arch": "amd64",
+    "version": "go1.15.15",
+    "sha256": "c76656a253cc4c7a0ba7ae006cadc0bf2d6df7066acb8df84460eac94dc3a7d1",
+    "size": 120983552,
+    "kind": "installer"
+   },
+   {
+    "filename": "go1.15.15.windows-386.zip",
+    "os": "windows",
+    "arch": "386",
+    "version": "go1.15.15",
+    "sha256": "4036abdeb36c7db380d05f3ffd087b754c34df06b202ee381da77f4c5a44aa58",
+    "size": 118256667,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.15.windows-386.msi",
+    "os": "windows",
+    "arch": "386",
+    "version": "go1.15.15",
+    "sha256": "04d406e45da74f67151ca9b720899d18a8707d77e83f07ba11f9b099ced3fff1",
+    "size": 103342080,
+    "kind": "installer"
+   },
+   {
+    "filename": "go1.15.15.src.tar.gz",
+    "os": "",
+    "arch": "",
+    "version": "go1.15.15",
+    "sha256": "0662ae3813330280d5f1a97a2ee23bbdbe3a5a7cfa6001b24a9873a19a0dc7ec",
+    "size": 23042945,
+    "kind": "source"
+   },
+   {
+    "filename": "go1.15.15.linux-s390x.tar.gz",
+    "os": "linux",
+    "arch": "s390x",
+    "version": "go1.15.15",
+    "sha256": "eae39d97df6b758636d5427be0b083dbf9d49007b302825ac6c8645de039aaab",
+    "size": 101198583,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.15.linux-ppc64le.tar.gz",
+    "os": "linux",
+    "arch": "ppc64le",
+    "version": "go1.15.15",
+    "sha256": "37f3b99e21d0324a6583159e14e42e57e56561abbf7bf68bef3d8f57b29e39c0",
+    "size": 96442143,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.15.linux-armv6l.tar.gz",
+    "os": "linux",
+    "arch": "armv6l",
+    "version": "go1.15.15",
+    "sha256": "7192603af50afb23c9d8cd14d2b2c19e0985a34d3eca685fa098df7893000d19",
+    "size": 97989611,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.15.linux-arm64.tar.gz",
+    "os": "linux",
+    "arch": "arm64",
+    "version": "go1.15.15",
+    "sha256": "714abb01af210473dd6af331094ad6847162eff81a7fc7241d24f5a85496c9fa",
+    "size": 97717057,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.15.linux-amd64.tar.gz",
+    "os": "linux",
+    "arch": "amd64",
+    "version": "go1.15.15",
+    "sha256": "0885cf046a9f099e260d98d9ec5d19ea9328f34c8dc4956e1d3cd87daaddb345",
+    "size": 121104410,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.15.linux-386.tar.gz",
+    "os": "linux",
+    "arch": "386",
+    "version": "go1.15.15",
+    "sha256": "3310fb0e48b0907bb520f6e3c6dcff63cc0913b92a76456f12980d0eb13b77d4",
+    "size": 100580037,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.15.freebsd-amd64.tar.gz",
+    "os": "freebsd",
+    "arch": "amd64",
+    "version": "go1.15.15",
+    "sha256": "1f80a20419b2618182ef5b9615dd990b32b952d81b354b373c6fd304527bb70c",
+    "size": 121000844,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.15.freebsd-386.tar.gz",
+    "os": "freebsd",
+    "arch": "386",
+    "version": "go1.15.15",
+    "sha256": "7174078a53e330cf351dc20bed6682033f44066d8aed754139bcaef52e53c214",
+    "size": 100310476,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.15.darwin-amd64.tar.gz",
+    "os": "darwin",
+    "arch": "amd64",
+    "version": "go1.15.15",
+    "sha256": "2f4c119524450ee94062a1ce7112fb88ce0fe4bb0303a302e002183a550c25c2",
+    "size": 122412248,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.15.darwin-amd64.pkg",
+    "os": "darwin",
+    "arch": "amd64",
+    "version": "go1.15.15",
+    "sha256": "f0e1877902ca88001cb768ae0dd8e974e58084ea6e64fb13f46289f842ef53ff",
+    "size": 122786419,
+    "kind": "installer"
+   }
+  ]
+ },
+ {
+  "version": "go1.15.14",
+  "stable": true,
+  "files": [
+   {
+    "filename": "go1.15.14.windows-amd64.zip",
+    "os": "windows",
+    "arch": "amd64",
+    "version": "go1.15.14",
+    "sha256": "88a77bebdd7276d0204f35e371aeaeb619f26b85d2ecf16f65cc713f4d49b9f7",
+    "size": 139063816,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.14.windows-amd64.msi",
+    "os": "windows",
+    "arch": "amd64",
+    "version": "go1.15.14",
+    "sha256": "cd030727ca202b6f47e745cf2b8b511cb63ca60a71ad441ee80dd225aceea4ae",
+    "size": 120963072,
+    "kind": "installer"
+   },
+   {
+    "filename": "go1.15.14.windows-386.zip",
+    "os": "windows",
+    "arch": "386",
+    "version": "go1.15.14",
+    "sha256": "2a920a672986599dd91cb8ed6a2e07ee4038495f1f5daca9a202fb1b05abae90",
+    "size": 118255090,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.14.windows-386.msi",
+    "os": "windows",
+    "arch": "386",
+    "version": "go1.15.14",
+    "sha256": "fe0318072a613259fd062d2b4676ab5ce36636796759d5379df0e0ea1395e819",
+    "size": 103342080,
+    "kind": "installer"
+   },
+   {
+    "filename": "go1.15.14.src.tar.gz",
+    "os": "",
+    "arch": "",
+    "version": "go1.15.14",
+    "sha256": "60a4a5c48d63d0a13eca8849009b624629ff429c8bc5d1a6a8c3c4da9f34e70a",
+    "size": 23041432,
+    "kind": "source"
+   },
+   {
+    "filename": "go1.15.14.linux-s390x.tar.gz",
+    "os": "linux",
+    "arch": "s390x",
+    "version": "go1.15.14",
+    "sha256": "cfe577ab8f7d779e45b2cb3a93062f7e5552e509d6e0c3e389bbfd6001ee4fe4",
+    "size": 101195993,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.14.linux-ppc64le.tar.gz",
+    "os": "linux",
+    "arch": "ppc64le",
+    "version": "go1.15.14",
+    "sha256": "e17c29518940885d9f4a2e02f63c922d1c2537e8c2cb68617f0ec84aaf7635ca",
+    "size": 96425186,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.14.linux-armv6l.tar.gz",
+    "os": "linux",
+    "arch": "armv6l",
+    "version": "go1.15.14",
+    "sha256": "a40fe975caf82daef311e22902eb4aeda1f0bd63a782c1ebd81911abed6c187b",
+    "size": 97986875,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.14.linux-arm64.tar.gz",
+    "os": "linux",
+    "arch": "arm64",
+    "version": "go1.15.14",
+    "sha256": "84e483d1ec7dae591f28f218485f8f67877412e24b8cea626bebf25b6d299c7f",
+    "size": 97716379,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.14.linux-amd64.tar.gz",
+    "os": "linux",
+    "arch": "amd64",
+    "version": "go1.15.14",
+    "sha256": "6f5410c113b803f437d7a1ee6f8f124100e536cc7361920f7e640fedf7add72d",
+    "size": 121105361,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.14.linux-386.tar.gz",
+    "os": "linux",
+    "arch": "386",
+    "version": "go1.15.14",
+    "sha256": "0216746103b8da20b23f91a86795bcf72e12428b2d07dfd3279a14b070ceaa74",
+    "size": 100576048,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.14.freebsd-amd64.tar.gz",
+    "os": "freebsd",
+    "arch": "amd64",
+    "version": "go1.15.14",
+    "sha256": "9ac2f0d4e35cb1275c10c83cb86c4a24374f34682298ca2d6cfff86349d21859",
+    "size": 120998872,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.14.freebsd-386.tar.gz",
+    "os": "freebsd",
+    "arch": "386",
+    "version": "go1.15.14",
+    "sha256": "520bd7eae9af3b769a5f4273f0b8e11951fe0376f179907e76e16bac880aff1b",
+    "size": 100312882,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.14.darwin-amd64.tar.gz",
+    "os": "darwin",
+    "arch": "amd64",
+    "version": "go1.15.14",
+    "sha256": "86b350467d5a09e717129d107072d242ec1cf9a1511acd46efe4ec825f6fe3dd",
+    "size": 122410213,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.14.darwin-amd64.pkg",
+    "os": "darwin",
+    "arch": "amd64",
+    "version": "go1.15.14",
+    "sha256": "d74c12e2ddf51475968901ff06ae3b9d186a8a6660b01da123b75df4e6813480",
+    "size": 122781738,
+    "kind": "installer"
+   }
+  ]
+ },
+ {
+  "version": "go1.15.13",
+  "stable": true,
+  "files": [
+   {
+    "filename": "go1.15.13.windows-amd64.zip",
+    "os": "windows",
+    "arch": "amd64",
+    "version": "go1.15.13",
+    "sha256": "d1cf76a11bbd5158715a3e3b6b7f0c623f5472f7c0e654c858913b74b09e7e81",
+    "size": 139053507,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.13.windows-amd64.msi",
+    "os": "windows",
+    "arch": "amd64",
+    "version": "go1.15.13",
+    "sha256": "151f8a71d0cba69dd889181dcece129d3bc5a15cd53251f09431de22a1119335",
+    "size": 120963072,
+    "kind": "installer"
+   },
+   {
+    "filename": "go1.15.13.windows-386.zip",
+    "os": "windows",
+    "arch": "386",
+    "version": "go1.15.13",
+    "sha256": "f6e7061495f43a6f26164d9430759a47382765fbf71c90ea714e275c9f4e99dc",
+    "size": 118245984,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.13.windows-386.msi",
+    "os": "windows",
+    "arch": "386",
+    "version": "go1.15.13",
+    "sha256": "50a717c7bccb9a3f03dc451bab85532f19513d77975c61717f1e8e6c997cb14d",
+    "size": 103325696,
+    "kind": "installer"
+   },
+   {
+    "filename": "go1.15.13.src.tar.gz",
+    "os": "",
+    "arch": "",
+    "version": "go1.15.13",
+    "sha256": "99069e7223479cce4553f84f874b9345f6f4045f27cf5089489b546da619a244",
+    "size": 23039791,
+    "kind": "source"
+   },
+   {
+    "filename": "go1.15.13.linux-s390x.tar.gz",
+    "os": "linux",
+    "arch": "s390x",
+    "version": "go1.15.13",
+    "sha256": "4448244965699706eff54d1f38917b8a896a27cf61a494f514818303c669a4b3",
+    "size": 101180575,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.13.linux-ppc64le.tar.gz",
+    "os": "linux",
+    "arch": "ppc64le",
+    "version": "go1.15.13",
+    "sha256": "1a27f62d8812c28700e49cae46b9a378410e9eb735c79b1722cbe685f1c72528",
+    "size": 96397400,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.13.linux-armv6l.tar.gz",
+    "os": "linux",
+    "arch": "armv6l",
+    "version": "go1.15.13",
+    "sha256": "00ff453f102c67ff6b790ba0cb10cecf73c8e8bbd9d913e5978ac8cc6323132f",
+    "size": 97990124,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.13.linux-arm64.tar.gz",
+    "os": "linux",
+    "arch": "arm64",
+    "version": "go1.15.13",
+    "sha256": "f3989dca4dea5fbadfec253d7c24e4111773b203e677abb1f01e768a99cc14e6",
+    "size": 97712702,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.13.linux-amd64.tar.gz",
+    "os": "linux",
+    "arch": "amd64",
+    "version": "go1.15.13",
+    "sha256": "3d3beec5fc66659018e09f40abb7274b10794229ba7c1e8bdb7d8ca77b656a13",
+    "size": 121120420,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.13.linux-386.tar.gz",
+    "os": "linux",
+    "arch": "386",
+    "version": "go1.15.13",
+    "sha256": "8df80ccbbd57b108ec43066925bf02aac47bc9e0236894dbd019f26944d27399",
+    "size": 100546337,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.13.freebsd-amd64.tar.gz",
+    "os": "freebsd",
+    "arch": "amd64",
+    "version": "go1.15.13",
+    "sha256": "36f451d50785ebca3aa1945bdfa475ec82c58dcadb84d4f9f969fccc53588071",
+    "size": 120985474,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.13.freebsd-386.tar.gz",
+    "os": "freebsd",
+    "arch": "386",
+    "version": "go1.15.13",
+    "sha256": "d99f07567dc97166d5a7f9f857a64e4bf3641c02bc55e8ea5e24c7d4ca6f21a7",
+    "size": 100305233,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.13.darwin-amd64.tar.gz",
+    "os": "darwin",
+    "arch": "amd64",
+    "version": "go1.15.13",
+    "sha256": "fc5415935430f75316374c918a20067d7a1883e4b0ffb33dc8c2ff34df6d55fe",
+    "size": 122395048,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.13.darwin-amd64.pkg",
+    "os": "darwin",
+    "arch": "amd64",
+    "version": "go1.15.13",
+    "sha256": "253117d3a9d3fb584a8d6a7eeedf9946be9a38b1db694b8802f5772e21802bb3",
+    "size": 122770924,
+    "kind": "installer"
+   }
+  ]
+ },
+ {
+  "version": "go1.15.12",
+  "stable": true,
+  "files": [
+   {
+    "filename": "go1.15.12.windows-amd64.zip",
+    "os": "windows",
+    "arch": "amd64",
+    "version": "go1.15.12",
+    "sha256": "313e5ebc59b497319c4c3f9560322fcc20f7bc3b4e47494afc3b2d63a42fb2a5",
+    "size": 139035845,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.12.windows-amd64.msi",
+    "os": "windows",
+    "arch": "amd64",
+    "version": "go1.15.12",
+    "sha256": "0b9715ab043698181093ab11f57df403e5e39156f92a880f1ef68025eb7b55ed",
+    "size": 120942592,
+    "kind": "installer"
+   },
+   {
+    "filename": "go1.15.12.windows-386.zip",
+    "os": "windows",
+    "arch": "386",
+    "version": "go1.15.12",
+    "sha256": "c31043ab926ae9b5b4a051baa85d19cfa24dac3b8255736824ec3a87aa6c9cf4",
+    "size": 118233658,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.12.windows-386.msi",
+    "os": "windows",
+    "arch": "386",
+    "version": "go1.15.12",
+    "sha256": "0c3c4e8c9f6b615f0e419da6569abdcff3cbbb6dfacfa3ae4a262b0b29338938",
+    "size": 103325696,
+    "kind": "installer"
+   },
+   {
+    "filename": "go1.15.12.src.tar.gz",
+    "os": "",
+    "arch": "",
+    "version": "go1.15.12",
+    "sha256": "1c6911937df4a277fa74e7b7efc3d08594498c4c4adc0b6c4ae3566137528091",
+    "size": 23035406,
+    "kind": "source"
+   },
+   {
+    "filename": "go1.15.12.linux-s390x.tar.gz",
+    "os": "linux",
+    "arch": "s390x",
+    "version": "go1.15.12",
+    "sha256": "9f1daa296e44ec0ce6b648e4e6d63210584b6c1ae2e46c77c8030b77514e8a8e",
+    "size": 101172120,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.12.linux-ppc64le.tar.gz",
+    "os": "linux",
+    "arch": "ppc64le",
+    "version": "go1.15.12",
+    "sha256": "c94c105e4e985b5675aa434845cced73a64bb050a8a96fa0e9b17dbea3ac6684",
+    "size": 96413509,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.12.linux-armv6l.tar.gz",
+    "os": "linux",
+    "arch": "armv6l",
+    "version": "go1.15.12",
+    "sha256": "6a20048f7061d06f590d869a5298e8c0ffc325e8faf0bb8b6a622ad007a53028",
+    "size": 97970507,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.12.linux-arm64.tar.gz",
+    "os": "linux",
+    "arch": "arm64",
+    "version": "go1.15.12",
+    "sha256": "a10161e6f0389c45ecd810e114acaba967ea3a4def551fcbb0b1e270996103ed",
+    "size": 97728932,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.12.linux-amd64.tar.gz",
+    "os": "linux",
+    "arch": "amd64",
+    "version": "go1.15.12",
+    "sha256": "bbdb935699e0b24d90e2451346da76121b2412d30930eabcd80907c230d098b7",
+    "size": 121101048,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.12.linux-386.tar.gz",
+    "os": "linux",
+    "arch": "386",
+    "version": "go1.15.12",
+    "sha256": "d186ccaa0080e301d35fa49a244877da6f08a1aeda3ed90438fee835538f7ece",
+    "size": 100558333,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.12.freebsd-amd64.tar.gz",
+    "os": "freebsd",
+    "arch": "amd64",
+    "version": "go1.15.12",
+    "sha256": "a63cca04ca822041219149402cf7b23c7f2d6b5d213329c1bf90cf9af62079d1",
+    "size": 120951529,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.12.freebsd-386.tar.gz",
+    "os": "freebsd",
+    "arch": "386",
+    "version": "go1.15.12",
+    "sha256": "b8153343d1c52d65c86be70f3eed2756cc2e0048a419fd9510ae4b8b99773190",
+    "size": 100275394,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.12.darwin-amd64.tar.gz",
+    "os": "darwin",
+    "arch": "amd64",
+    "version": "go1.15.12",
+    "sha256": "05062d111062a5475f6f637018b09dc907bb6815bb156c26ebccf8d47ee35e2c",
+    "size": 122384700,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.12.darwin-amd64.pkg",
+    "os": "darwin",
+    "arch": "amd64",
+    "version": "go1.15.12",
+    "sha256": "91cb985e63114633f91729a59f40ef43b67f70807b1d34325f58f8bdc0b0bf75",
+    "size": 122750009,
+    "kind": "installer"
+   }
+  ]
+ },
+ {
+  "version": "go1.15.11",
+  "stable": true,
+  "files": [
+   {
+    "filename": "go1.15.11.windows-amd64.zip",
+    "os": "windows",
+    "arch": "amd64",
+    "version": "go1.15.11",
+    "sha256": "56f63de17cd739287de6d9f3cfdad3b781ad3e4a18aae20ece994ee97c1819fd",
+    "size": 139024980,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.11.windows-amd64.msi",
+    "os": "windows",
+    "arch": "amd64",
+    "version": "go1.15.11",
+    "sha256": "148667008ebd74f51372140a92ab192ea2bc20329d64ab79349e8d908938847f",
+    "size": 120930304,
+    "kind": "installer"
+   },
+   {
+    "filename": "go1.15.11.windows-386.zip",
+    "os": "windows",
+    "arch": "386",
+    "version": "go1.15.11",
+    "sha256": "b0a64a2a2dedefd1559acf866e393c8e00294dbde113875ee9d8cf3561886123",
+    "size": 118224267,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.11.windows-386.msi",
+    "os": "windows",
+    "arch": "386",
+    "version": "go1.15.11",
+    "sha256": "3224c9ea3ddfdb4eb56c6c5fc761fd3bb2d61430ac589fb147d77df50f662ffe",
+    "size": 103313408,
+    "kind": "installer"
+   },
+   {
+    "filename": "go1.15.11.src.tar.gz",
+    "os": "",
+    "arch": "",
+    "version": "go1.15.11",
+    "sha256": "f25b2441d4c76cf63cde94d59bab237cc33e8a2a139040d904c8630f46d061e5",
+    "size": 23029946,
+    "kind": "source"
+   },
+   {
+    "filename": "go1.15.11.linux-s390x.tar.gz",
+    "os": "linux",
+    "arch": "s390x",
+    "version": "go1.15.11",
+    "sha256": "2fb25504fa525e24dbba7e8e7fa2d91c42c66272dc176d5270dec77099124c75",
+    "size": 101167488,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.11.linux-ppc64le.tar.gz",
+    "os": "linux",
+    "arch": "ppc64le",
+    "version": "go1.15.11",
+    "sha256": "4916ef0fc4c40db2dcc503a3473b325ed21d100cc77f1cc7e0a3aede19eec628",
+    "size": 96409553,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.11.linux-armv6l.tar.gz",
+    "os": "linux",
+    "arch": "armv6l",
+    "version": "go1.15.11",
+    "sha256": "dba11ed018fc7b5774ca996c4bdb847f8f9535cdc4932eb09a43c390813af4c9",
+    "size": 97964010,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.11.linux-arm64.tar.gz",
+    "os": "linux",
+    "arch": "arm64",
+    "version": "go1.15.11",
+    "sha256": "bfc8f07945296e97c6d28c7999d86b5cab51c7a87eb2b22ca6781c41a6bb6f2d",
+    "size": 97699191,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.11.linux-amd64.tar.gz",
+    "os": "linux",
+    "arch": "amd64",
+    "version": "go1.15.11",
+    "sha256": "8825b72d74b14e82b54ba3697813772eb94add3abf70f021b6bdebe193ed01ec",
+    "size": 121079391,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.11.linux-386.tar.gz",
+    "os": "linux",
+    "arch": "386",
+    "version": "go1.15.11",
+    "sha256": "2de51fc6873d8b688d7451cfc87443ef49404af98bbab9c8a36fb6c4bc95e4de",
+    "size": 100537845,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.11.freebsd-amd64.tar.gz",
+    "os": "freebsd",
+    "arch": "amd64",
+    "version": "go1.15.11",
+    "sha256": "38fb5516e86934dc385d1b06433692034f38ed38117e8017e211a0efe55ed44e",
+    "size": 120942573,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.11.freebsd-386.tar.gz",
+    "os": "freebsd",
+    "arch": "386",
+    "version": "go1.15.11",
+    "sha256": "c9ac9e8e12b9a4639d8a164815d2ccab86f7c1534672c1d03933e7180d2ace5d",
+    "size": 100264795,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.11.darwin-amd64.tar.gz",
+    "os": "darwin",
+    "arch": "amd64",
+    "version": "go1.15.11",
+    "sha256": "651c78408b2c047b7ccccb6b244c5de9eab927c87594ff6bd9540d43c9706671",
+    "size": 122357211,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.11.darwin-amd64.pkg",
+    "os": "darwin",
+    "arch": "amd64",
+    "version": "go1.15.11",
+    "sha256": "18a143c21bba34d671fa952d66dc1221f0c39ac340ebbe6ef91770488e3eaf04",
+    "size": 122724893,
+    "kind": "installer"
+   }
+  ]
+ },
+ {
+  "version": "go1.15.10",
+  "stable": true,
+  "files": [
+   {
+    "filename": "go1.15.10.windows-amd64.zip",
+    "os": "windows",
+    "arch": "amd64",
+    "version": "go1.15.10",
+    "sha256": "ba30d211e96d57ce2becf17fe9ebe1d958eba29384c5aeb1e99f9209b44dd7c2",
+    "size": 139013975,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.10.windows-amd64.msi",
+    "os": "windows",
+    "arch": "amd64",
+    "version": "go1.15.10",
+    "sha256": "187a8bdd1b138ab16d6048108a0ffa793278a57a4ec57f8cef5e8887a3fd4363",
+    "size": 120942592,
+    "kind": "installer"
+   },
+   {
+    "filename": "go1.15.10.windows-386.zip",
+    "os": "windows",
+    "arch": "386",
+    "version": "go1.15.10",
+    "sha256": "b76f65ac809775d13d06f5c7d9daba8a8855cda3cac51297e925c4dbfa965070",
+    "size": 118212768,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.10.windows-386.msi",
+    "os": "windows",
+    "arch": "386",
+    "version": "go1.15.10",
+    "sha256": "69143a922c59026691a79062ab61ae8d44babcb7f90de2148eb71eff4acd3999",
+    "size": 103313408,
+    "kind": "installer"
+   },
+   {
+    "filename": "go1.15.10.src.tar.gz",
+    "os": "",
+    "arch": "",
+    "version": "go1.15.10",
+    "sha256": "c1dbca6e0910b41d61a95bf9878f6d6e93d15d884c226b91d9d4b1113c10dd65",
+    "size": 23021993,
+    "kind": "source"
+   },
+   {
+    "filename": "go1.15.10.linux-s390x.tar.gz",
+    "os": "linux",
+    "arch": "s390x",
+    "version": "go1.15.10",
+    "sha256": "230e0e50fe0df0ba380804c02f1d88a801c6dee38582c4a9502e79dc744c7bb0",
+    "size": 101144833,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.10.linux-ppc64le.tar.gz",
+    "os": "linux",
+    "arch": "ppc64le",
+    "version": "go1.15.10",
+    "sha256": "49128af704c37a356b1d14d814e4cf64218a8c6cabb22249e0c0068b35f710d3",
+    "size": 96390789,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.10.linux-armv6l.tar.gz",
+    "os": "linux",
+    "arch": "armv6l",
+    "version": "go1.15.10",
+    "sha256": "10739f7a87544acca49c9f1c025ae1821ce83601228a968bd7102357ae89887b",
+    "size": 97945905,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.10.linux-arm64.tar.gz",
+    "os": "linux",
+    "arch": "arm64",
+    "version": "go1.15.10",
+    "sha256": "ca3f3e84d863d8e758bfaab65430b12b6cff8f5a5648139245321d3401da64a7",
+    "size": 97699860,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.10.linux-amd64.tar.gz",
+    "os": "linux",
+    "arch": "amd64",
+    "version": "go1.15.10",
+    "sha256": "4aa1267517df32f2bf1cc3d55dfc27d0c6b2c2b0989449c96dd19273ccca051d",
+    "size": 121069320,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.10.linux-386.tar.gz",
+    "os": "linux",
+    "arch": "386",
+    "version": "go1.15.10",
+    "sha256": "69a29473c9e8eded5b5885a45773e4f1b9661383ce577199c4c70efe4c67bc59",
+    "size": 100540945,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.10.freebsd-amd64.tar.gz",
+    "os": "freebsd",
+    "arch": "amd64",
+    "version": "go1.15.10",
+    "sha256": "eab5abfc8a1794d921b39da6e61a7638a7aaab401a645231f38238c7eaadc8b1",
+    "size": 120945944,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.10.freebsd-386.tar.gz",
+    "os": "freebsd",
+    "arch": "386",
+    "version": "go1.15.10",
+    "sha256": "3b86b71075e258f0f09ea025317fe78ed0e49d9da59acb5e29e67eaea835166e",
+    "size": 100245123,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.10.darwin-amd64.tar.gz",
+    "os": "darwin",
+    "arch": "amd64",
+    "version": "go1.15.10",
+    "sha256": "19648b2495eade4c77797c789cd437e81ae575d84594f7c7f63d25c6ed24865e",
+    "size": 122358976,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.10.darwin-amd64.pkg",
+    "os": "darwin",
+    "arch": "amd64",
+    "version": "go1.15.10",
+    "sha256": "da78f2cbc0aa9f8adb2ed940dfa2b1217728e8672afca42f27110d9fe780ee3c",
+    "size": 122720833,
+    "kind": "installer"
+   }
+  ]
+ },
+ {
+  "version": "go1.15.9",
+  "stable": true,
+  "files": [
+   {
+    "filename": "go1.15.9.windows-amd64.zip",
+    "os": "windows",
+    "arch": "amd64",
+    "version": "go1.15.9",
+    "sha256": "daf5c44fb8d6ddd001a0d1eca3d562167101f3d18129c9c935728449036dd79c",
+    "size": 139007200,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.9.windows-amd64.msi",
+    "os": "windows",
+    "arch": "amd64",
+    "version": "go1.15.9",
+    "sha256": "d9547445a5aee95108ec0f88a7a6ceec5ed51560054df085ac803beba9059aa0",
+    "size": 120930304,
+    "kind": "installer"
+   },
+   {
+    "filename": "go1.15.9.windows-386.zip",
+    "os": "windows",
+    "arch": "386",
+    "version": "go1.15.9",
+    "sha256": "27e623d4dd3daf36ad0e90616b8161ae4fbfa2ff6c2541671dc31bb1b90c9abd",
+    "size": 118206264,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.9.windows-386.msi",
+    "os": "windows",
+    "arch": "386",
+    "version": "go1.15.9",
+    "sha256": "60252583eccf6df62a3e5bef365d5148b52a9241f022d46b2fd935ee82b72cca",
+    "size": 103309312,
+    "kind": "installer"
+   },
+   {
+    "filename": "go1.15.9.src.tar.gz",
+    "os": "",
+    "arch": "",
+    "version": "go1.15.9",
+    "sha256": "90983b9c84a92417337dc1942ff066fc8b3a69733b8b5493fd0b9b9db1ead60f",
+    "size": 23019739,
+    "kind": "source"
+   },
+   {
+    "filename": "go1.15.9.linux-s390x.tar.gz",
+    "os": "linux",
+    "arch": "s390x",
+    "version": "go1.15.9",
+    "sha256": "f16f3dcea7d0fbe3182622f596ae63e63cc5ad4a26545b65660dbb44d8c05614",
+    "size": 101130411,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.9.linux-ppc64le.tar.gz",
+    "os": "linux",
+    "arch": "ppc64le",
+    "version": "go1.15.9",
+    "sha256": "dc30dff3b549b891f0326029dc3823e76af64f9e8352134b51c8cffbf7e567b9",
+    "size": 96376700,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.9.linux-armv6l.tar.gz",
+    "os": "linux",
+    "arch": "armv6l",
+    "version": "go1.15.9",
+    "sha256": "9dac54ad8afe282bd18b09d6ed0fad3b663187f914db2e43ee1b6968135ef01d",
+    "size": 97943842,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.9.linux-arm64.tar.gz",
+    "os": "linux",
+    "arch": "arm64",
+    "version": "go1.15.9",
+    "sha256": "8ea5f3718abde696b4762882b5a9753a8ec148c9b32e3d37e5f2e52a1f9b12ca",
+    "size": 97697797,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.9.linux-amd64.tar.gz",
+    "os": "linux",
+    "arch": "amd64",
+    "version": "go1.15.9",
+    "sha256": "a55f3e75bc1098045851d40ea74f9d77efc7958e9af85131a96ca387d38b1834",
+    "size": 121068907,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.9.linux-386.tar.gz",
+    "os": "linux",
+    "arch": "386",
+    "version": "go1.15.9",
+    "sha256": "469868ac51391b84e153d09c82dacf2c75bf81b96dc13c9bee15fdd50b3406de",
+    "size": 100525550,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.9.freebsd-amd64.tar.gz",
+    "os": "freebsd",
+    "arch": "amd64",
+    "version": "go1.15.9",
+    "sha256": "fb094473efce8df290cf0a78dba8dbf5c76462851eeba3efb5f579746d6117e3",
+    "size": 120939644,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.9.freebsd-386.tar.gz",
+    "os": "freebsd",
+    "arch": "386",
+    "version": "go1.15.9",
+    "sha256": "59ae769d9331c8339d2e2606260beb34030e4e9d5b3b0a727b225ef8615f7fef",
+    "size": 100240798,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.9.darwin-amd64.tar.gz",
+    "os": "darwin",
+    "arch": "amd64",
+    "version": "go1.15.9",
+    "sha256": "1a7b20801933050490a6114392b6c842f3c4774bb43e15240c1faf98a01d645a",
+    "size": 122354600,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.9.darwin-amd64.pkg",
+    "os": "darwin",
+    "arch": "amd64",
+    "version": "go1.15.9",
+    "sha256": "7bce1b7b374d84474dbb7a242f01935e56db3f1c97901fcc70ad733b2e530aa3",
+    "size": 122718740,
+    "kind": "installer"
+   }
+  ]
+ },
+ {
+  "version": "go1.15.8",
+  "stable": true,
+  "files": [
+   {
+    "filename": "go1.15.8.windows-amd64.zip",
+    "os": "windows",
+    "arch": "amd64",
+    "version": "go1.15.8",
+    "sha256": "ef05b7141d3c217fb076f0e27249e144296234df96ead8751c0b76784079df97",
+    "size": 139005264,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.8.windows-amd64.msi",
+    "os": "windows",
+    "arch": "amd64",
+    "version": "go1.15.8",
+    "sha256": "edc1bd458f090ac4823ec79181b350bd5446073b4432acaf2b326c85415d7daa",
+    "size": 120930304,
+    "kind": "installer"
+   },
+   {
+    "filename": "go1.15.8.windows-386.zip",
+    "os": "windows",
+    "arch": "386",
+    "version": "go1.15.8",
+    "sha256": "091cf23efe75e1e039e10808878d56467f12a28edb0de935ce5aab31aab5d52c",
+    "size": 118206126,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.8.windows-386.msi",
+    "os": "windows",
+    "arch": "386",
+    "version": "go1.15.8",
+    "sha256": "80e07b56a3bbc22e4970c3c7232cdf97875c79f30120d9c202fc68590001455a",
+    "size": 103292928,
+    "kind": "installer"
+   },
+   {
+    "filename": "go1.15.8.src.tar.gz",
+    "os": "",
+    "arch": "",
+    "version": "go1.15.8",
+    "sha256": "540c0ab7781084d124991321ed1458e479982de94454a98afab6acadf38497c2",
+    "size": 23018628,
+    "kind": "source"
+   },
+   {
+    "filename": "go1.15.8.linux-s390x.tar.gz",
+    "os": "linux",
+    "arch": "s390x",
+    "version": "go1.15.8",
+    "sha256": "ba922f54fe99dee3246705bacbfac27fa88375439025429297aa1e9caf3f2297",
+    "size": 101130165,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.8.linux-ppc64le.tar.gz",
+    "os": "linux",
+    "arch": "ppc64le",
+    "version": "go1.15.8",
+    "sha256": "c6ddeab22b23ee33f5e8f06f9667e2092f48dbc6d5db553a66f7fe21da73fbfa",
+    "size": 96378870,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.8.linux-armv6l.tar.gz",
+    "os": "linux",
+    "arch": "armv6l",
+    "version": "go1.15.8",
+    "sha256": "708c398cb9e5029cfd5b654370978bf0e797d4d4a71153c06c7378db7e249a53",
+    "size": 97941770,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.8.linux-arm64.tar.gz",
+    "os": "linux",
+    "arch": "arm64",
+    "version": "go1.15.8",
+    "sha256": "0e31ea4bf53496b0f0809730520dee98c0ae5c530f3701a19df0ba0a327bf3d2",
+    "size": 97697452,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.8.linux-amd64.tar.gz",
+    "os": "linux",
+    "arch": "amd64",
+    "version": "go1.15.8",
+    "sha256": "d3379c32a90fdf9382166f8f48034c459a8cc433730bc9476d39d9082c94583b",
+    "size": 121066822,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.8.linux-386.tar.gz",
+    "os": "linux",
+    "arch": "386",
+    "version": "go1.15.8",
+    "sha256": "a0cc9df6d04f89af8396278d171087894a453a03a950b0f60a4ac18b480f758f",
+    "size": 100524880,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.8.freebsd-amd64.tar.gz",
+    "os": "freebsd",
+    "arch": "amd64",
+    "version": "go1.15.8",
+    "sha256": "ec5b0e690593f8d6e1964221b1a95b2a3efdedcfd3562f4113cd1c0b6180a5ee",
+    "size": 120937877,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.8.freebsd-386.tar.gz",
+    "os": "freebsd",
+    "arch": "386",
+    "version": "go1.15.8",
+    "sha256": "46fbf0fe03910569113989bf608e56f847df685efccdcee29d8ab3b9752211f8",
+    "size": 100239248,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.8.darwin-amd64.tar.gz",
+    "os": "darwin",
+    "arch": "amd64",
+    "version": "go1.15.8",
+    "sha256": "7df8977d3befd2ec41479abed1c93aac93cb320dcbe4808950d28948911da854",
+    "size": 122353388,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.15.8.darwin-amd64.pkg",
+    "os": "darwin",
+    "arch": "amd64",
+    "version": "go1.15.8",
+    "sha256": "26fd5e7b7422f00116aaccbc74b78475e13497669220dcf96e135d871389e6e8",
+    "size": 122705614,
     "kind": "installer"
    }
   ]
@@ -1864,6 +4972,147 @@
     "version": "go1.15beta1",
     "sha256": "cd9b1e60c62080ea4c8e3066dad016e994354e97dab407c04e8e4c41e473e568",
     "size": 126101765,
+    "kind": "installer"
+   }
+  ]
+ },
+ {
+  "version": "go1.14.15",
+  "stable": true,
+  "files": [
+   {
+    "filename": "go1.14.15.windows-amd64.zip",
+    "os": "windows",
+    "arch": "amd64",
+    "version": "go1.14.15",
+    "sha256": "189bc564d537d86f80c70757ee4c29fb1c2c6e8d05bb6de1242a03a96ac850cb",
+    "size": 138273428,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.14.15.windows-amd64.msi",
+    "os": "windows",
+    "arch": "amd64",
+    "version": "go1.14.15",
+    "sha256": "504a2eecd0b2075efa412208cc1578101828ab00775ee372d311c0d512172c12",
+    "size": 121118720,
+    "kind": "installer"
+   },
+   {
+    "filename": "go1.14.15.windows-386.zip",
+    "os": "windows",
+    "arch": "386",
+    "version": "go1.14.15",
+    "sha256": "6d990df3f60fc120d7e2ce7ffcaad102c1d595fb631ad2bd097217458004cd30",
+    "size": 118462703,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.14.15.windows-386.msi",
+    "os": "windows",
+    "arch": "386",
+    "version": "go1.14.15",
+    "sha256": "13345fbb611f77df96734fd80b5638493a37b16169589c2ab961ffd09ae8bc75",
+    "size": 103972864,
+    "kind": "installer"
+   },
+   {
+    "filename": "go1.14.15.src.tar.gz",
+    "os": "",
+    "arch": "",
+    "version": "go1.14.15",
+    "sha256": "7ed13b2209e54a451835997f78035530b331c5b6943cdcd68a3d815fdc009149",
+    "size": 22557340,
+    "kind": "source"
+   },
+   {
+    "filename": "go1.14.15.linux-s390x.tar.gz",
+    "os": "linux",
+    "arch": "s390x",
+    "version": "go1.14.15",
+    "sha256": "8e121c947ec531628d37ad0292623f22c8f9fecac6067192b5cce34b36cedd79",
+    "size": 105703775,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.14.15.linux-ppc64le.tar.gz",
+    "os": "linux",
+    "arch": "ppc64le",
+    "version": "go1.14.15",
+    "sha256": "64d82004270bcd00948dbed9f1a123ef844ceb7633e6a87a5ca7ef8bdf59cfc1",
+    "size": 100290977,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.14.15.linux-armv6l.tar.gz",
+    "os": "linux",
+    "arch": "armv6l",
+    "version": "go1.14.15",
+    "sha256": "a63960d9b9c14954e299ffe060c0574ffb91ab810837da5941853b664d0652da",
+    "size": 102148192,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.14.15.linux-arm64.tar.gz",
+    "os": "linux",
+    "arch": "arm64",
+    "version": "go1.14.15",
+    "sha256": "4d964166a189c22032521c63935437c304bb7f01673b196898cff525897a1c27",
+    "size": 101413983,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.14.15.linux-amd64.tar.gz",
+    "os": "linux",
+    "arch": "amd64",
+    "version": "go1.14.15",
+    "sha256": "c64a57b374a81f7cf1408d2c410a28c6f142414f1ffa9d1062de1d653b0ae0d6",
+    "size": 124135233,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.14.15.linux-386.tar.gz",
+    "os": "linux",
+    "arch": "386",
+    "version": "go1.14.15",
+    "sha256": "cab962eaf954378bbb5b24f703baf3b471e9690a109082dd688593fbb6f9008e",
+    "size": 105235796,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.14.15.freebsd-amd64.tar.gz",
+    "os": "freebsd",
+    "arch": "amd64",
+    "version": "go1.14.15",
+    "sha256": "06b355212b788e348369e1d09bb55aed73da4b3569af5a5f8801dd88182df99f",
+    "size": 124090347,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.14.15.freebsd-386.tar.gz",
+    "os": "freebsd",
+    "arch": "386",
+    "version": "go1.14.15",
+    "sha256": "4d8eb68aa9bdc1d13cebe8884c6bf4f9cc0b8baea383620113ff6a2ac17c8d63",
+    "size": 105026782,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.14.15.darwin-amd64.tar.gz",
+    "os": "darwin",
+    "arch": "amd64",
+    "version": "go1.14.15",
+    "sha256": "cc116e7522d1d1bcb606ce413555c4f2d5c86c0c8d5e5074a0d57b303d8edb50",
+    "size": 125507930,
+    "kind": "archive"
+   },
+   {
+    "filename": "go1.14.15.darwin-amd64.pkg",
+    "os": "darwin",
+    "arch": "amd64",
+    "version": "go1.14.15",
+    "sha256": "692f2f2d02725cf093d1efa51b2fb5b8d6adf02708f964a1b6229f7fdbacae57",
+    "size": 125863660,
     "kind": "installer"
    }
   ]
@@ -20390,7 +23639,7 @@
     "os": "windows",
     "arch": "amd64",
     "version": "go1.6rc2",
-    "sha256": "",
+    "sha256": "0ba3ec69473a90528365ef5626b5ff892f52ab2709b0ff0a777a81f5a6f4f251",
     "size": 91458374,
     "kind": "archive"
    },
@@ -20399,7 +23648,7 @@
     "os": "windows",
     "arch": "amd64",
     "version": "go1.6rc2",
-    "sha256": "",
+    "sha256": "7b577bd9f1b08794892fd86b6c20e00df73814097435d878c15a637a51573b84",
     "size": 74498048,
     "kind": "installer"
    },
@@ -20408,7 +23657,7 @@
     "os": "windows",
     "arch": "386",
     "version": "go1.6rc2",
-    "sha256": "",
+    "sha256": "7ecbd3c72a996e6d7f81a3c621beab30a25edb134048e0694cbd520e10eb104e",
     "size": 77843859,
     "kind": "archive"
    },
@@ -20417,7 +23666,7 @@
     "os": "windows",
     "arch": "386",
     "version": "go1.6rc2",
-    "sha256": "",
+    "sha256": "4d4ba0b54421a6a6197cb48ef15c3e64089c355864fe24a4961ce55ecd42cc16",
     "size": 64135168,
     "kind": "installer"
    },
@@ -20426,7 +23675,7 @@
     "os": "",
     "arch": "",
     "version": "go1.6rc2",
-    "sha256": "",
+    "sha256": "92914a23cde7e34e1d017175d785e5850fbb28f323a145028e2e26053ef1a598",
     "size": 12602910,
     "kind": "source"
    },
@@ -20435,7 +23684,7 @@
     "os": "linux",
     "arch": "armv6l",
     "version": "go1.6rc2",
-    "sha256": "",
+    "sha256": "cadcb5530e9a68d5ede1ab5115d985c829344eae7d04dce8e9840423536cef4f",
     "size": 70703688,
     "kind": "archive"
    },
@@ -20444,7 +23693,7 @@
     "os": "linux",
     "arch": "amd64",
     "version": "go1.6rc2",
-    "sha256": "",
+    "sha256": "9c19fa0fe32ee9bff79123d47147a5fd15fec451806bf5644a01173a86a8a4b9",
     "size": 84757980,
     "kind": "archive"
    },
@@ -20453,7 +23702,7 @@
     "os": "linux",
     "arch": "386",
     "version": "go1.6rc2",
-    "sha256": "",
+    "sha256": "e3bcdefc942883137f68230e67b69046003d5a18064bbe6c8944f3f3b3e6b6fc",
     "size": 71961115,
     "kind": "archive"
    },
@@ -20462,7 +23711,7 @@
     "os": "freebsd",
     "arch": "amd64",
     "version": "go1.6rc2",
-    "sha256": "",
+    "sha256": "98b1b7cef91c07ce2edcc755ca7e3aefaf705cfbaa4cc8a9a8ed7a6860d9d9e8",
     "size": 84803852,
     "kind": "archive"
    },
@@ -20471,7 +23720,7 @@
     "os": "freebsd",
     "arch": "386",
     "version": "go1.6rc2",
-    "sha256": "",
+    "sha256": "178661226760d48b99bd4d2df0b2859b5a92bc039d1e689925edf277f380f692",
     "size": 72000533,
     "kind": "archive"
    },
@@ -20480,7 +23729,7 @@
     "os": "darwin",
     "arch": "amd64",
     "version": "go1.6rc2",
-    "sha256": "",
+    "sha256": "e6458d5ef2245085210b0813dc91f98ba4c93319bd9be7b1baf5844fd96dab5e",
     "size": 84646105,
     "kind": "archive"
    },
@@ -20489,7 +23738,7 @@
     "os": "darwin",
     "arch": "amd64",
     "version": "go1.6rc2",
-    "sha256": "",
+    "sha256": "33ce64510ea0962e86d48b80e720d4b7b6a11a1ee683b14cc8a4cee22c46558b",
     "size": 84731537,
     "kind": "installer"
    }
@@ -20504,7 +23753,7 @@
     "os": "windows",
     "arch": "amd64",
     "version": "go1.6rc1",
-    "sha256": "",
+    "sha256": "30e4826e44b0875ceec415b0119e923f21fc9bdb7062ebfa8de33e8d7c1746e5",
     "size": 91444831,
     "kind": "archive"
    },
@@ -20513,7 +23762,7 @@
     "os": "windows",
     "arch": "amd64",
     "version": "go1.6rc1",
-    "sha256": "",
+    "sha256": "7591a653d59a4fdda4625df6727dda8be7907f42458ecd982eababbecf0c6e59",
     "size": 74485760,
     "kind": "installer"
    },
@@ -20522,7 +23771,7 @@
     "os": "windows",
     "arch": "386",
     "version": "go1.6rc1",
-    "sha256": "",
+    "sha256": "a745189d2e6bc79153cd368e040d998513f597e0e3a7a495844dd7d00378be8b",
     "size": 77832913,
     "kind": "archive"
    },
@@ -20531,7 +23780,7 @@
     "os": "windows",
     "arch": "386",
     "version": "go1.6rc1",
-    "sha256": "",
+    "sha256": "8d74ef6ff3538bd603b46fb462e6ef337dafbb793a908bd0e71290913624e186",
     "size": 64110592,
     "kind": "installer"
    },
@@ -20540,7 +23789,7 @@
     "os": "",
     "arch": "",
     "version": "go1.6rc1",
-    "sha256": "",
+    "sha256": "2d1a6756f24227dcee955add4af7d194eb4a8c3656b2c4ce778994e21a533a83",
     "size": 12597286,
     "kind": "source"
    },
@@ -20549,7 +23798,7 @@
     "os": "linux",
     "arch": "armv6l",
     "version": "go1.6rc1",
-    "sha256": "",
+    "sha256": "4340efa4836a7ddfc61d00e396e0f496a5ca5cf8bc598dc3b5f50707e6107f59",
     "size": 70699278,
     "kind": "archive"
    },
@@ -20558,7 +23807,7 @@
     "os": "linux",
     "arch": "amd64",
     "version": "go1.6rc1",
-    "sha256": "",
+    "sha256": "6a8aeab9548faf933a66dafeb809bd8623c5bba1ca9626c2f28ef619b5723218",
     "size": 84736060,
     "kind": "archive"
    },
@@ -20567,7 +23816,7 @@
     "os": "linux",
     "arch": "386",
     "version": "go1.6rc1",
-    "sha256": "",
+    "sha256": "462de63b0b84817eadf7589522a5c789f2ddb4a136a30daaa6de8459a9d1c857",
     "size": 71949934,
     "kind": "archive"
    },
@@ -20576,7 +23825,7 @@
     "os": "freebsd",
     "arch": "amd64",
     "version": "go1.6rc1",
-    "sha256": "",
+    "sha256": "773b5a6cf938d723712024882041e489a921e7c8c7dc9e5d6b203e7a28a05146",
     "size": 84783936,
     "kind": "archive"
    },
@@ -20585,7 +23834,7 @@
     "os": "freebsd",
     "arch": "386",
     "version": "go1.6rc1",
-    "sha256": "",
+    "sha256": "46e1bdd354c65a9efc25b1f450209f9602ba82e206de9d7d3b100a180985e527",
     "size": 71984120,
     "kind": "archive"
    },
@@ -20594,7 +23843,7 @@
     "os": "darwin",
     "arch": "amd64",
     "version": "go1.6rc1",
-    "sha256": "",
+    "sha256": "64e892f8a6b480050c6d95600b131dc03987c27eed91be6e7ee9931267d8dc89",
     "size": 84636922,
     "kind": "archive"
    },
@@ -20603,7 +23852,7 @@
     "os": "darwin",
     "arch": "amd64",
     "version": "go1.6rc1",
-    "sha256": "",
+    "sha256": "b863db2c2a5646eaa6a1b97da711383f1a6b774090613b53d0193db7792d402a",
     "size": 84723339,
     "kind": "installer"
    }
@@ -20618,7 +23867,7 @@
     "os": "windows",
     "arch": "amd64",
     "version": "go1.6beta2",
-    "sha256": "",
+    "sha256": "e4e20af2171a77c1812ddc6fa00296e73460fb92b1c89660ce2109cdfad589d6",
     "size": 92575989,
     "kind": "archive"
    },
@@ -20627,7 +23876,7 @@
     "os": "windows",
     "arch": "amd64",
     "version": "go1.6beta2",
-    "sha256": "",
+    "sha256": "a5d1e267427c67eae786a21ee6aa1d18343e2454428f815dd0de4a202c71f7a8",
     "size": 75448320,
     "kind": "installer"
    },
@@ -20636,7 +23885,7 @@
     "os": "windows",
     "arch": "386",
     "version": "go1.6beta2",
-    "sha256": "",
+    "sha256": "2ed31dbac0133d97705a71f1e42e0b40ff176ec03f8ab607b5ba71955ecc9e7d",
     "size": 78919759,
     "kind": "archive"
    },
@@ -20645,7 +23894,7 @@
     "os": "windows",
     "arch": "386",
     "version": "go1.6beta2",
-    "sha256": "",
+    "sha256": "3751332ccd114935acfb5b9fe8b040e637b267984fa1ce61c1e5e331299b7385",
     "size": 65007616,
     "kind": "installer"
    },
@@ -20654,7 +23903,7 @@
     "os": "",
     "arch": "",
     "version": "go1.6beta2",
-    "sha256": "",
+    "sha256": "8b23d15a3edf1d154ceea5e9ca6370fc60e7f57fb1c28aa8a44c40f8f3167c6d",
     "size": 12538927,
     "kind": "source"
    },
@@ -20663,7 +23912,7 @@
     "os": "linux",
     "arch": "armv6l",
     "version": "go1.6beta2",
-    "sha256": "",
+    "sha256": "269671775d2d4e8d929be595d9c02367962b7edb942aa344f8a8a310dd408d56",
     "size": 71732610,
     "kind": "archive"
    },
@@ -20672,7 +23921,7 @@
     "os": "linux",
     "arch": "amd64",
     "version": "go1.6beta2",
-    "sha256": "",
+    "sha256": "7ddf9797c7baaac2c16eed1a8d42f9a446223301c7dc8771ea805f211828e6a5",
     "size": 85859620,
     "kind": "archive"
    },
@@ -20681,7 +23930,7 @@
     "os": "linux",
     "arch": "386",
     "version": "go1.6beta2",
-    "sha256": "",
+    "sha256": "dd6a6a5ae1d130608e082d274c775819e7a3c3a9e34b982619f0281c41f25cf9",
     "size": 73002970,
     "kind": "archive"
    },
@@ -20690,7 +23939,7 @@
     "os": "freebsd",
     "arch": "amd64",
     "version": "go1.6beta2",
-    "sha256": "",
+    "sha256": "9a3149901565578f6d5a406101b0a50567c9818e631231414cc720d9184dd0d4",
     "size": 85865241,
     "kind": "archive"
    },
@@ -20699,7 +23948,7 @@
     "os": "freebsd",
     "arch": "386",
     "version": "go1.6beta2",
-    "sha256": "",
+    "sha256": "b7fa31d39f879516aac359860a0ef4127832cd63bb4394a566059faa393472bb",
     "size": 73042092,
     "kind": "archive"
    },
@@ -20708,7 +23957,7 @@
     "os": "darwin",
     "arch": "amd64",
     "version": "go1.6beta2",
-    "sha256": "",
+    "sha256": "bf0a4348586a0b55df6bd99d1ee3b3a37273d0bc483a7c44169dcf13b61bc46b",
     "size": 85740488,
     "kind": "archive"
    },
@@ -20717,7 +23966,7 @@
     "os": "darwin",
     "arch": "amd64",
     "version": "go1.6beta2",
-    "sha256": "",
+    "sha256": "df875fc61f6b40677eeaf160768a3c8cd74e0ae5cb6db269a008a7a584f87b1a",
     "size": 85812882,
     "kind": "installer"
    }

--- a/goreleases/testdata/vcr/gldo_client_default.yaml
+++ b/goreleases/testdata/vcr/gldo_client_default.yaml
@@ -11,6 +11,2583 @@ interactions:
     body: |
       [
        {
+        "version": "go1.17",
+        "stable": true,
+        "files": [
+         {
+          "filename": "go1.17.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.17",
+          "sha256": "3a70e5055509f347c0fb831ca07a2bf3b531068f349b14a3c652e9b5b67beb5d",
+          "size": 22178549,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.17.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.17",
+          "sha256": "355bd544ce08d7d484d9d7de05a71b5c6f5bc10aa4b316688c2192aeb3dacfd1",
+          "size": 135938157,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.17.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.17",
+          "sha256": "8b6c8c0cccc8b685f857c50a511adb497a3a5cdd5b8970f03f95aa3f02bce404",
+          "size": 136352140,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.17.darwin-arm64.tar.gz",
+          "os": "darwin",
+          "arch": "arm64",
+          "version": "go1.17",
+          "sha256": "da4e3e3c194bf9eed081de8842a157120ef44a7a8d7c820201adae7b0e28b20b",
+          "size": 129400752,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.17.darwin-arm64.pkg",
+          "os": "darwin",
+          "arch": "arm64",
+          "version": "go1.17",
+          "sha256": "e638a506c8bb4fe9f6686489cd7640ffe15c3a5119c3a783eaee373f4fa520d6",
+          "size": 129828668,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.17.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.17",
+          "sha256": "6819a7a11b8351d5d5768f2fff666abde97577602394f132cb7f85b3a7151f05",
+          "size": 105472481,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.17.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.17",
+          "sha256": "15c184c83d99441d719da201b26256455eee85a808747c404b4183e9aa6c64b4",
+          "size": 133579378,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.17.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.17",
+          "sha256": "c19e3227a6ac6329db91d1af77bbf239ccd760a259c16e6b9c932d527ff14848",
+          "size": 105601636,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.17.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.17",
+          "sha256": "6bf89fc4f5ad763871cf7eac80a2d594492de7a818303283f1366a7f6a30372d",
+          "size": 134787877,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.17.linux-arm64.tar.gz",
+          "os": "linux",
+          "arch": "arm64",
+          "version": "go1.17",
+          "sha256": "01a9af009ada22122d3fcb9816049c1d21842524b38ef5d5a0e2ee4b26d7c3e7",
+          "size": 102591993,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.17.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.17",
+          "sha256": "ae89d33f4e4acc222bdb04331933d5ece4ae71039812f6ccd7493cb3e8ddfb4e",
+          "size": 103066091,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.17.linux-ppc64le.tar.gz",
+          "os": "linux",
+          "arch": "ppc64le",
+          "version": "go1.17",
+          "sha256": "ee84350114d532bf15f096198c675aafae9ff091dc4cc69eb49e1817ff94dbd7",
+          "size": 101004564,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.17.linux-s390x.tar.gz",
+          "os": "linux",
+          "arch": "s390x",
+          "version": "go1.17",
+          "sha256": "a50aaecf054f393575f969a9105d5c6864dd91afc5287d772449033fbafcf7e3",
+          "size": 105756590,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.17.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.17",
+          "sha256": "c5afdd2ea4969f2b44637e913b04f7c15265d7beb60924a28063722670a52feb",
+          "size": 120971817,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.17.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.17",
+          "sha256": "e9680bb0d7b0f15fd9436f416eab6ef71c9e3ac65773b05c21f8fa384e9d25e1",
+          "size": 105435136,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.17.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.17",
+          "sha256": "2a18bd65583e221be8b9b7c2fbe3696c40f6e27c2df689bbdcc939d49651d151",
+          "size": 150367305,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.17.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.17",
+          "sha256": "705254e0a459edae2c6bf4c88be0b4a14ac1cbbf9607a379112235f0271e6c4b",
+          "size": 130314240,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.17.windows-arm64.zip",
+          "os": "windows",
+          "arch": "arm64",
+          "version": "go1.17",
+          "sha256": "5256f92f643d9022394ddc84de5c74fe8660c2151daaa199b12e60e542d694ae",
+          "size": 116670266,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.17.windows-arm64.msi",
+          "os": "windows",
+          "arch": "arm64",
+          "version": "go1.17",
+          "sha256": "e4709daca79de47fa94c59cc1ec076ad0597b9edad8919fb051eadba7c1c2995",
+          "size": 101990400,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.16.7",
+        "stable": true,
+        "files": [
+         {
+          "filename": "go1.16.7.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.16.7",
+          "sha256": "1a9f2894d3d878729f7045072f30becebe243524cf2fce4e0a7b248b1e0654ac",
+          "size": 20922206,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.16.7.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.16.7",
+          "sha256": "8018bf556e833912d455fab7ea279caa542239b6675c6b3861e9002380c70080",
+          "size": 130203260,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.7.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.16.7",
+          "sha256": "24e95aa60f516cfc34139cfd1192efe97724ea62ab36ad9404df36b926b1f879",
+          "size": 130588410,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.16.7.darwin-arm64.tar.gz",
+          "os": "darwin",
+          "arch": "arm64",
+          "version": "go1.16.7",
+          "sha256": "7721706560d6a17b80b1f68efc0ebef27028bd51547127362ae0c0dac287b24b",
+          "size": 125703153,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.7.darwin-arm64.pkg",
+          "os": "darwin",
+          "arch": "arm64",
+          "version": "go1.16.7",
+          "sha256": "c0924334dec1b39226af6ac8c63473b4f9e7689bd9837fdd5e1508d9a831fae1",
+          "size": 126064386,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.16.7.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.16.7",
+          "sha256": "09d2db7b6e8636cce9af249d75ffaaf5f1fda7042725f46e43e8c3e9e012da4f",
+          "size": 102930482,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.7.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.16.7",
+          "sha256": "cf43ecac8a68c040354e8a45ba167ebc631091976ac370b6f1e444623bc77f37",
+          "size": 129011611,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.7.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.16.7",
+          "sha256": "5c0c8891fa88993f2193fbc9dd5cca6c250c89aa8c12bbaa382b6ff38139bcc3",
+          "size": 103084876,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.7.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.16.7",
+          "sha256": "7fe7a73f55ba3e2285da36f8b085e5c0159e9564ef5f63ee0ed6b818ade8ef04",
+          "size": 129034961,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.7.linux-arm64.tar.gz",
+          "os": "linux",
+          "arch": "arm64",
+          "version": "go1.16.7",
+          "sha256": "63d6b53ecbd2b05c1f0e9903c92042663f2f68afdbb67f4d0d12700156869bac",
+          "size": 99603989,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.7.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.16.7",
+          "sha256": "b2973ceeae234866368baf9469fb7b9444857e50dc785ba879d98a0aa208a12b",
+          "size": 100281970,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.7.linux-ppc64le.tar.gz",
+          "os": "linux",
+          "arch": "ppc64le",
+          "version": "go1.16.7",
+          "sha256": "03e02b2ac6dc1601203f335385b9bbe15a55677066d9a1a1280b5fcfa6ec4738",
+          "size": 98094639,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.7.linux-s390x.tar.gz",
+          "os": "linux",
+          "arch": "s390x",
+          "version": "go1.16.7",
+          "sha256": "5f691c9551710ebb17bbda04389944aa7332f42ab28f92516a69fbd7860e7e9f",
+          "size": 103222266,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.7.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.16.7",
+          "sha256": "53b32b48ee2797acf2c5fa8f83c0d42406ae6b5df7e3a57ccbe94cf6272faeec",
+          "size": 117859438,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.7.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.16.7",
+          "sha256": "a8e4ed71d5bc393884f981928c4ca74e95130a6d032a7ba3e414e8e2ac2b5710",
+          "size": 102830080,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.16.7.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.16.7",
+          "sha256": "56b3a9024268f226f679c3a8ffb21f4214a75f84050b2c395b362ae2cc8e53e9",
+          "size": 143997221,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.7.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.16.7",
+          "sha256": "75597307c368ae1f728f9e7a2c2d5814225664b5b8d915d34c0d4eb2d53d0831",
+          "size": 124407808,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.16.6",
+        "stable": true,
+        "files": [
+         {
+          "filename": "go1.16.6.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.16.6",
+          "sha256": "a3a5d4bc401b51db065e4f93b523347a4d343ae0c0b08a65c3423b05a138037d",
+          "size": 20923044,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.16.6.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.16.6",
+          "sha256": "e4e83e7c6891baa00062ed37273ce95835f0be77ad8203a29ec56dbf3d87508a",
+          "size": 130220543,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.6.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.16.6",
+          "sha256": "0b49b6cbe50b30aa0a5bb9f8ccdbb43f9cd3d9a3c36a769b8e46777d694539b5",
+          "size": 130602070,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.16.6.darwin-arm64.tar.gz",
+          "os": "darwin",
+          "arch": "arm64",
+          "version": "go1.16.6",
+          "sha256": "17bb7e8fb6f46ce3ac7851466d62f8985f2fef975eed8f59c236a0cc0c220dc5",
+          "size": 125731706,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.6.darwin-arm64.pkg",
+          "os": "darwin",
+          "arch": "arm64",
+          "version": "go1.16.6",
+          "sha256": "c70d238f3a181a3acc9ccc3c54af5434012a0ba8f19520ba95b04a05df38fab5",
+          "size": 126119422,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.16.6.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.16.6",
+          "sha256": "0c54c675a67a28e205f02dc903f1f0e611e621cbdf46ff5c4e84f9c4bb396f85",
+          "size": 102939329,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.6.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.16.6",
+          "sha256": "49b17ebb37429b88f90c5b3592070db277f6ffb25fb4f3b4800c73cf2f8ea66d",
+          "size": 129020620,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.6.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.16.6",
+          "sha256": "33d028b6d2a4abeb74cccd55024500ae49d5edfb08a30665db0b49cd1052c37e",
+          "size": 103097252,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.6.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.16.6",
+          "sha256": "be333ef18b3016e9d7cb7b1ff1fdb0cac800ca0be4cf2290fe613b3d069dfe0d",
+          "size": 129049323,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.6.linux-arm64.tar.gz",
+          "os": "linux",
+          "arch": "arm64",
+          "version": "go1.16.6",
+          "sha256": "9e38047463da6daecab9017cd0599f33f84991e68263752cfab49253bbc98c30",
+          "size": 99625421,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.6.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.16.6",
+          "sha256": "b1ca342e81897da3f25da4e75ae29b267db1674fe7222d9bfc4c666bcf6fce69",
+          "size": 100280065,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.6.linux-ppc64le.tar.gz",
+          "os": "linux",
+          "arch": "ppc64le",
+          "version": "go1.16.6",
+          "sha256": "62b5e9bb9440b7166241e5b7d5f49c7372b36429c8308a8456ee46fc1397a0fe",
+          "size": 98091111,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.6.linux-s390x.tar.gz",
+          "os": "linux",
+          "arch": "s390x",
+          "version": "go1.16.6",
+          "sha256": "f07de592165539b3e9fbc6d067affea930b33d54cff5b5d3630d82b8682d3c3f",
+          "size": 103255022,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.6.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.16.6",
+          "sha256": "2c9c5ce429fe7899a62efe25bcb8fc66ee87d1ab81e7148c6c114c65304fada4",
+          "size": 117878011,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.6.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.16.6",
+          "sha256": "89e31a7483ca1c71a8a508516e60792885b7d77a59b4f3991f891089090c97c5",
+          "size": 102846464,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.16.6.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.16.6",
+          "sha256": "c1132ba4e6263a1712355fb0745bf4f23e1602e1661c20f071e08bdcc5fe8db5",
+          "size": 144011586,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.6.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.16.6",
+          "sha256": "8caa75a1604a8519abc92a0ca55b60adfc675bb4eb13f1c9f6fab9cca54b617d",
+          "size": 124420096,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.16.5",
+        "stable": true,
+        "files": [
+         {
+          "filename": "go1.16.5.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.16.5",
+          "sha256": "7bfa7e5908c7cc9e75da5ddf3066d7cbcf3fd9fa51945851325eebc17f50ba80",
+          "size": 20921372,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.16.5.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.16.5",
+          "sha256": "be761716d5bfc958a5367440f68ba6563509da2f539ad1e1864bd42fe553f277",
+          "size": 130223787,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.5.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.16.5",
+          "sha256": "c0d4e37377dd83cb78e38bdd2166ab815cbfdd79ac15ce0b35846293ee97caa5",
+          "size": 130599145,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.16.5.darwin-arm64.tar.gz",
+          "os": "darwin",
+          "arch": "arm64",
+          "version": "go1.16.5",
+          "sha256": "7b1bed9b63d69f1caa14a8d6911fbd743e8c37e21ed4e5b5afdbbaa80d070059",
+          "size": 125731583,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.5.darwin-arm64.pkg",
+          "os": "darwin",
+          "arch": "arm64",
+          "version": "go1.16.5",
+          "sha256": "59b3844112ce54ec68e5844d4fd8e58fb537e1d656b8f5b5f98a8e6c98b7b9ca",
+          "size": 126101701,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.16.5.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.16.5",
+          "sha256": "d2c6a5d17200c70160d5a79b23320f7802fb5e2620fa58ab0b43c147fc018192",
+          "size": 102938013,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.5.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.16.5",
+          "sha256": "7110fe0c16e45641cf5a457b1bf1cba76275abca298a4dc93b60b4b33697310f",
+          "size": 129024293,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.5.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.16.5",
+          "sha256": "a37c6b71d0b673fe8dfeb2a8b3de78824f05d680ad32b7ac6b58c573fa6695de",
+          "size": 103100007,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.5.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.16.5",
+          "sha256": "b12c23023b68de22f74c0524f10b753e7b08b1504cb7e417eccebdd3fae49061",
+          "size": 129049763,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.5.linux-arm64.tar.gz",
+          "os": "linux",
+          "arch": "arm64",
+          "version": "go1.16.5",
+          "sha256": "d5446b46ef6f36fdffa852f73dfbbe78c1ddf010b99fa4964944b9ae8b4d6799",
+          "size": 99636582,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.5.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.16.5",
+          "sha256": "93cacacfbe87e3106b5bf5821de106f0f0a43c8bd1029826d44445c15df795a5",
+          "size": 100289753,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.5.linux-ppc64le.tar.gz",
+          "os": "linux",
+          "arch": "ppc64le",
+          "version": "go1.16.5",
+          "sha256": "fad2da6c86ede8448d2d0e66e1776e2f0ae9169714eade29b9ffbbdede7fc6cc",
+          "size": 98094423,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.5.linux-s390x.tar.gz",
+          "os": "linux",
+          "arch": "s390x",
+          "version": "go1.16.5",
+          "sha256": "21085f6a3568fae639edf383cce78bcb00d8f415e5e3d7feb04b6124e8e9efc1",
+          "size": 103243212,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.5.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.16.5",
+          "sha256": "bee3e7b3dda252725de4df63f5182b30e579bf9f613bda2efe0e0919fe34112d",
+          "size": 117878589,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.5.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.16.5",
+          "sha256": "b9b8d0346418ccc25bd23b9a2af29f1c172149453289fe4fc4a8bf35b8af368d",
+          "size": 102850560,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.16.5.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.16.5",
+          "sha256": "0a3fa279ae5b91bc8c88017198c8f1ba5d9925eb6e5d7571316e567c73add39d",
+          "size": 144011630,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.5.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.16.5",
+          "sha256": "322dd8c585f37b62c9e603c84747b97a7a65b56fcef56b64e3021ccad90785b2",
+          "size": 124416000,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.16.4",
+        "stable": true,
+        "files": [
+         {
+          "filename": "go1.16.4.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.16.4",
+          "sha256": "ae4f6b6e2a1677d31817984655a762074b5356da50fb58722b99104870d43503",
+          "size": 20917203,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.16.4.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.16.4",
+          "sha256": "18fe94775763db3878717393b6d41371b0b45206055e49b3838328120c977d13",
+          "size": 130208172,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.4.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.16.4",
+          "sha256": "9f9b940d0f4b3ac764f0a33d78384a87b804aab29d1aacbdc9bca3a3480e9272",
+          "size": 130590489,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.16.4.darwin-arm64.tar.gz",
+          "os": "darwin",
+          "arch": "arm64",
+          "version": "go1.16.4",
+          "sha256": "cb6b972cc42e669f3585c648198cd5b6f6d7a0811d413ad64b50c02ba06ccc3a",
+          "size": 125717159,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.4.darwin-arm64.pkg",
+          "os": "darwin",
+          "arch": "arm64",
+          "version": "go1.16.4",
+          "sha256": "f665ea35f9fd1ffaf2f51e48e17f303f5f255383b5330c40de516e4c81ed32a9",
+          "size": 126082903,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.16.4.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.16.4",
+          "sha256": "7cf2bc8a175d6d656861165bfc554f92dc78d2abf5afe5631db3579555d97409",
+          "size": 102938104,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.4.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.16.4",
+          "sha256": "ccdd2b76de1941b60734408fda0d750aaa69330d8a07430eed4c56bdb3502f6f",
+          "size": 129019405,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.4.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.16.4",
+          "sha256": "cd1b146ef6e9006f27dd99e9687773e7fef30e8c985b7d41bff33e955a3bb53a",
+          "size": 103088952,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.4.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.16.4",
+          "sha256": "7154e88f5a8047aad4b80ebace58a059e36e7e2e4eb3b383127a28c711b4ff59",
+          "size": 129044044,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.4.linux-arm64.tar.gz",
+          "os": "linux",
+          "arch": "arm64",
+          "version": "go1.16.4",
+          "sha256": "8b18eb05ddda2652d69ab1b1dd1f40dd731799f43c6a58b512ad01ae5b5bba21",
+          "size": 99614019,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.4.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.16.4",
+          "sha256": "a53391a800ddec749ee90d38992babb27b95cfb864027350c737b9aa8e069494",
+          "size": 100296464,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.4.linux-ppc64le.tar.gz",
+          "os": "linux",
+          "arch": "ppc64le",
+          "version": "go1.16.4",
+          "sha256": "80cfac566e344096a8df8f37bbd21f89e76a6fbe601406565d71a87a665fc125",
+          "size": 98090739,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.4.linux-s390x.tar.gz",
+          "os": "linux",
+          "arch": "s390x",
+          "version": "go1.16.4",
+          "sha256": "d6431881b3573dc29ecc24fbeab5e5ec25d8c9273aa543769c86a1a3bbac1ddf",
+          "size": 103219497,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.4.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.16.4",
+          "sha256": "e75c0b114a09eb5499874162b208931dc260de0fedaeedac8621bf263c974605",
+          "size": 117870065,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.4.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.16.4",
+          "sha256": "a561574cc2c11d157feaf06f807a8c56a75dabcee688b95a7f7f826067385812",
+          "size": 102842368,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.16.4.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.16.4",
+          "sha256": "d40139b7ade8a3008e3240a6f86fe8f899a9c465c917e11dac8758af216f5eb0",
+          "size": 143991377,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.4.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.16.4",
+          "sha256": "9ae1cafad5f206f004cfe4e9e9b64e4710cb69c83f6221da89c113b6f2e8dec8",
+          "size": 124403712,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.16.3",
+        "stable": true,
+        "files": [
+         {
+          "filename": "go1.16.3.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.16.3",
+          "sha256": "b298d29de9236ca47a023e382313bcc2d2eed31dfa706b60a04103ce83a71a25",
+          "size": 20912861,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.16.3.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.16.3",
+          "sha256": "6bb1cf421f8abc2a9a4e39140b7397cdae6aca3e8d36dcff39a1a77f4f1170ac",
+          "size": 130179623,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.3.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.16.3",
+          "sha256": "af29670bff9a1f9c078b1f3b027a8cbc006f6044baaafc7dd32416a374dd6248",
+          "size": 130580567,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.16.3.darwin-arm64.tar.gz",
+          "os": "darwin",
+          "arch": "arm64",
+          "version": "go1.16.3",
+          "sha256": "f4e96bbcd5d2d1942f5b55d9e4ab19564da4fad192012f6d7b0b9b055ba4208f",
+          "size": 125672548,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.3.darwin-arm64.pkg",
+          "os": "darwin",
+          "arch": "arm64",
+          "version": "go1.16.3",
+          "sha256": "ff26b39bd2a5ebb6416061eaa41e59b44f02199cbb2442f5e217c722ffe6db91",
+          "size": 126059396,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.16.3.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.16.3",
+          "sha256": "31ecd11d497684fa8b0f01ba784590c4c760943665fdc4fe0adaa1405c71736c",
+          "size": 102914441,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.3.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.16.3",
+          "sha256": "ffbd920b309e62e807457b11d80e8c17fefe3ef6de423aaba4b1e270b2ca4c3d",
+          "size": 128978039,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.3.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.16.3",
+          "sha256": "48b2d1481db756c88c18b1f064dbfc3e265ce4a775a23177ca17e25d13a24c5d",
+          "size": 103078077,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.3.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.16.3",
+          "sha256": "951a3c7c6ce4e56ad883f97d9db74d3d6d80d5fec77455c6ada6c1f7ac4776d2",
+          "size": 129021323,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.3.linux-arm64.tar.gz",
+          "os": "linux",
+          "arch": "arm64",
+          "version": "go1.16.3",
+          "sha256": "566b1d6f17d2bc4ad5f81486f0df44f3088c3ed47a3bec4099d8ed9939e90d5d",
+          "size": 99595201,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.3.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.16.3",
+          "sha256": "0dae30385e3564a557dac7f12a63eedc73543e6da0f6017990e214ce8cc8797c",
+          "size": 100291185,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.3.linux-ppc64le.tar.gz",
+          "os": "linux",
+          "arch": "ppc64le",
+          "version": "go1.16.3",
+          "sha256": "5eb046bbbbc7fe2591846a4303884cb5a01abb903e3e61e33459affe7874e811",
+          "size": 98073094,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.3.linux-s390x.tar.gz",
+          "os": "linux",
+          "arch": "s390x",
+          "version": "go1.16.3",
+          "sha256": "3e8bd7bde533a73fd6fa75b5288678ef397e76c198cfb26b8ae086035383b1cf",
+          "size": 103190200,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.3.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.16.3",
+          "sha256": "a3c16e1531bf9726f47911c4a9ed7cb665a6207a51c44f10ebad4db63b4bcc5a",
+          "size": 117845179,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.3.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.16.3",
+          "sha256": "75c501ce9c7e542653da034db02d8d9dc6cecef2804df9fc9cc6f90708a02d8c",
+          "size": 102817792,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.16.3.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.16.3",
+          "sha256": "a4400345135b36cb7942e52bbaf978b66814738b855eeff8de879a09fd99de7f",
+          "size": 143970079,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.3.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.16.3",
+          "sha256": "850cf9e4b0ab0369ab2750c6ab25725b6a298490d09bf3fde61b08f770328f4c",
+          "size": 124391424,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.16.2",
+        "stable": true,
+        "files": [
+         {
+          "filename": "go1.16.2.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.16.2",
+          "sha256": "37ca14287a23cb8ba2ac3f5c3dd8adbc1f7a54b9701a57824bf19a0b271f83ea",
+          "size": 20905135,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.16.2.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.16.2",
+          "sha256": "c98cde81517c5daf427f3071412f39d5bc58f6120e90a0d94cc51480fa04dbc1",
+          "size": 130169242,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.2.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.16.2",
+          "sha256": "c3a2e19e49041d835c18a055f34fda1ea56a8599ad12f03a1bfe88d7608f3f5e",
+          "size": 130562159,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.16.2.darwin-arm64.tar.gz",
+          "os": "darwin",
+          "arch": "arm64",
+          "version": "go1.16.2",
+          "sha256": "9238b5187aedd1a049bb88abef15aa2ea3fee3458be0e982bea0dac5e5f0d811",
+          "size": 125655613,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.2.darwin-arm64.pkg",
+          "os": "darwin",
+          "arch": "arm64",
+          "version": "go1.16.2",
+          "sha256": "3fc031254c0e5f44f4ab8874f9a0f1ae8a8e5f516b6962001deae9cd014db107",
+          "size": 126039948,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.16.2.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.16.2",
+          "sha256": "09cd0eae0a3e8766984e775cf76c9a902bbf8347c1fa21c45be019690cedef82",
+          "size": 102894010,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.2.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.16.2",
+          "sha256": "b0b0a5dc9e69b0f7da7cb0e0123efef9e6f344161574f21c7a401d3df37d2dd6",
+          "size": 128959952,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.2.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.16.2",
+          "sha256": "3638abf8e8272a4ddc3e5189487c932d680abfb151e2c48ae18c9a04a90ded73",
+          "size": 103056782,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.2.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.16.2",
+          "sha256": "542e936b19542e62679766194364f45141fde55169db2d8d01046555ca9eb4b8",
+          "size": 129010536,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.2.linux-arm64.tar.gz",
+          "os": "linux",
+          "arch": "arm64",
+          "version": "go1.16.2",
+          "sha256": "6924601d998a0917694fd14261347e3798bd2ad6b13c4d7f2edd70c9d57f62ab",
+          "size": 99574374,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.2.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.16.2",
+          "sha256": "49765b1ac36f77a84ce8186b08713c3811db5426e4ecfaa4344453e12d756c22",
+          "size": 100267745,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.2.linux-ppc64le.tar.gz",
+          "os": "linux",
+          "arch": "ppc64le",
+          "version": "go1.16.2",
+          "sha256": "e1dcc9b460b2d522added8dfce764a06c5e455c8047b45b67a06f7f5ab19c4e0",
+          "size": 98049911,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.2.linux-s390x.tar.gz",
+          "os": "linux",
+          "arch": "s390x",
+          "version": "go1.16.2",
+          "sha256": "a686743b0803d54e051756ce946d9d72436f23e9f815739c947934e0052bf9ff",
+          "size": 103180786,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.2.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.16.2",
+          "sha256": "f8e96864d13eec9ece84e64ebf61d89753dc93359f040c5f1496baaf34542d73",
+          "size": 117823582,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.2.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.16.2",
+          "sha256": "644bb475e520e2aef1d9905229faa2c90e46507f8ee8d8d0614f2525f40cf618",
+          "size": 102789120,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.16.2.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.16.2",
+          "sha256": "baa7d69482365930ecc5c0b99e6a5935180988a2e7b49aa8a22dbcd39f4064b7",
+          "size": 143964966,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.2.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.16.2",
+          "sha256": "ad7c65aa63842e6a2ae15a32f01d1e0d8d79b032869203c7dd84e4891468719f",
+          "size": 124362752,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.16.1",
+        "stable": true,
+        "files": [
+         {
+          "filename": "go1.16.1.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.16.1",
+          "sha256": "680a500cd8048750121677dd4dc055fdfd680ae83edc7ed60a4b927e466228eb",
+          "size": 20897580,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.16.1.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.16.1",
+          "sha256": "a760929667253cdaa5b10117f536a912be2b0be1006215ff86e957f98f76fd58",
+          "size": 130169195,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.1.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.16.1",
+          "sha256": "1e804a23a4ef02080e1862e0e2aa20940893a62e5509394acce41de210d92e47",
+          "size": 130534745,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.16.1.darwin-arm64.tar.gz",
+          "os": "darwin",
+          "arch": "arm64",
+          "version": "go1.16.1",
+          "sha256": "de2847f49faac2d0608b4afc324cbb3029a496c946db616c294d26082e45f32d",
+          "size": 125667833,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.1.darwin-arm64.pkg",
+          "os": "darwin",
+          "arch": "arm64",
+          "version": "go1.16.1",
+          "sha256": "e3af4dfc639b23e4e9f6f04e45e8b01d29acfea4f1d6d28636264b9d7761642c",
+          "size": 126071876,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.16.1.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.16.1",
+          "sha256": "cec49fba5d6341f07ddd97b2dc91d40a79e27b36eed0461177f632b54da72b1e",
+          "size": 102872299,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.1.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.16.1",
+          "sha256": "e03eafde19a7ccc5d24f2051a56bbe9a5bc21c0c04cbc0ada9d05417b737b0ca",
+          "size": 128955933,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.1.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.16.1",
+          "sha256": "de050a1161fe450968e9db139f48685312657297065e81508ced7ca7cb61d913",
+          "size": 103041855,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.1.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.16.1",
+          "sha256": "3edc22f8332231c3ba8be246f184b736b8d28f06ce24f08168d8ecf052549769",
+          "size": 129001205,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.1.linux-arm64.tar.gz",
+          "os": "linux",
+          "arch": "arm64",
+          "version": "go1.16.1",
+          "sha256": "fa8a6034e51e5cceaa477027d44c2f9a2f1d9540e8ce881014c526c11290a180",
+          "size": 99557358,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.1.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.16.1",
+          "sha256": "c49e1680de0d72917e6a16423adcc0c57a86e6ec2324510ddeb4bff35e46ecb4",
+          "size": 100227463,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.1.linux-ppc64le.tar.gz",
+          "os": "linux",
+          "arch": "ppc64le",
+          "version": "go1.16.1",
+          "sha256": "5412da4f2cd5dd8d2292b187e9c03afa5ccc058abdfaf4c534f064bd96074d3a",
+          "size": 98050171,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.1.linux-s390x.tar.gz",
+          "os": "linux",
+          "arch": "s390x",
+          "version": "go1.16.1",
+          "sha256": "b5a0e661993702f4059f23038df399c9d7c88d11002f317907aac0423f769ebf",
+          "size": 103185911,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.1.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.16.1",
+          "sha256": "604a220963932623af4568b1fa11204c2d58d48595a8bdf04c1e9e00359baeb4",
+          "size": 117807426,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.1.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.16.1",
+          "sha256": "c31917732f1bd0084a33a23ce1b05136b7d76e75029357b1ffe5f60eb735c1f5",
+          "size": 102768640,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.16.1.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.16.1",
+          "sha256": "5349a85c190d953e9d59570cad6798c57b18e0bd93794927f25a89e695a5b5be",
+          "size": 143940869,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.1.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.16.1",
+          "sha256": "d90561184fae94c1e9054107067635fd2f8249f13195685ced6c5fdf4bfd57bb",
+          "size": 124379136,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.16",
+        "stable": true,
+        "files": [
+         {
+          "filename": "go1.16.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.16",
+          "sha256": "7688063d55656105898f323d90a79a39c378d86fe89ae192eb3b7fc46347c95a",
+          "size": 20895394,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.16.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.16",
+          "sha256": "6000a9522975d116bf76044967d7e69e04e982e9625330d9a539a8b45395f9a8",
+          "size": 130169373,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.16",
+          "sha256": "2906bd8e6bf60d0e15d2e771318ed382f67da88509bb86f9b21018022ab788b1",
+          "size": 130535233,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.16.darwin-arm64.tar.gz",
+          "os": "darwin",
+          "arch": "arm64",
+          "version": "go1.16",
+          "sha256": "4dac57c00168d30bbd02d95131d5de9ca88e04f2c5a29a404576f30ae9b54810",
+          "size": 125661998,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.darwin-arm64.pkg",
+          "os": "darwin",
+          "arch": "arm64",
+          "version": "go1.16",
+          "sha256": "8f0989ee009007581632b0e3721fe98e605dacddfc5e94b94801c1f2be3bea1c",
+          "size": 126070282,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.16.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.16",
+          "sha256": "d7d6c70b05a7c2f68b48aab5ab8cb5116b8444c9ddad131673b152e7cff7c726",
+          "size": 102870677,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.16",
+          "sha256": "40b03216f6945fb6883a50604fc7f409a83f62171607229a9c598e701e684f8a",
+          "size": 128957442,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.16",
+          "sha256": "ea435a1ac6d497b03e367fdfb74b33e961d813883468080f6e239b3b03bea6aa",
+          "size": 103040576,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.16",
+          "sha256": "013a489ebb3e24ef3d915abe5b94c3286c070dfe0818d5bca8108f1d6e8440d2",
+          "size": 129003129,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.linux-arm64.tar.gz",
+          "os": "linux",
+          "arch": "arm64",
+          "version": "go1.16",
+          "sha256": "3770f7eb22d05e25fbee8fb53c2a4e897da043eb83c69b9a14f8d98562cd8098",
+          "size": 99556292,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.16",
+          "sha256": "d1d9404b1dbd77afa2bdc70934e10fbfcf7d785c372efc29462bb7d83d0a32fd",
+          "size": 100235835,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.linux-ppc64le.tar.gz",
+          "os": "linux",
+          "arch": "ppc64le",
+          "version": "go1.16",
+          "sha256": "27a1aaa988e930b7932ce459c8a63ad5b3333b3a06b016d87ff289f2a11aacd6",
+          "size": 98046447,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.linux-s390x.tar.gz",
+          "os": "linux",
+          "arch": "s390x",
+          "version": "go1.16",
+          "sha256": "be4c9e4e2cf058efc4e3eb013a760cb989ddc4362f111950c990d1c63b27ccbe",
+          "size": 103192604,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.16",
+          "sha256": "481492a17d42193d471b93b7a06da3555331bd833b76336afc87be820c48933f",
+          "size": 117807019,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.16",
+          "sha256": "93b95aa7fa181153363a5f3a4448538b02312a12f2989249d4263c03defd9ec0",
+          "size": 102756352,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.16.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.16",
+          "sha256": "5cc88fa506b3d5c453c54c3ea218fc8dd05d7362ae1de15bb67986b72089ce93",
+          "size": 143940754,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.16",
+          "sha256": "0fd550a74f6c8ef5df405751f5e39a0ba25786930c5d61503bf71d3c3efa2414",
+          "size": 124403712,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.15.15",
+        "stable": true,
+        "files": [
+         {
+          "filename": "go1.15.15.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.15.15",
+          "sha256": "0662ae3813330280d5f1a97a2ee23bbdbe3a5a7cfa6001b24a9873a19a0dc7ec",
+          "size": 23042945,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.15.15.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.15.15",
+          "sha256": "2f4c119524450ee94062a1ce7112fb88ce0fe4bb0303a302e002183a550c25c2",
+          "size": 122412248,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.15.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.15.15",
+          "sha256": "f0e1877902ca88001cb768ae0dd8e974e58084ea6e64fb13f46289f842ef53ff",
+          "size": 122786419,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.15.15.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.15.15",
+          "sha256": "7174078a53e330cf351dc20bed6682033f44066d8aed754139bcaef52e53c214",
+          "size": 100310476,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.15.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.15.15",
+          "sha256": "1f80a20419b2618182ef5b9615dd990b32b952d81b354b373c6fd304527bb70c",
+          "size": 121000844,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.15.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.15.15",
+          "sha256": "3310fb0e48b0907bb520f6e3c6dcff63cc0913b92a76456f12980d0eb13b77d4",
+          "size": 100580037,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.15.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.15.15",
+          "sha256": "0885cf046a9f099e260d98d9ec5d19ea9328f34c8dc4956e1d3cd87daaddb345",
+          "size": 121104410,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.15.linux-arm64.tar.gz",
+          "os": "linux",
+          "arch": "arm64",
+          "version": "go1.15.15",
+          "sha256": "714abb01af210473dd6af331094ad6847162eff81a7fc7241d24f5a85496c9fa",
+          "size": 97717057,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.15.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.15.15",
+          "sha256": "7192603af50afb23c9d8cd14d2b2c19e0985a34d3eca685fa098df7893000d19",
+          "size": 97989611,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.15.linux-ppc64le.tar.gz",
+          "os": "linux",
+          "arch": "ppc64le",
+          "version": "go1.15.15",
+          "sha256": "37f3b99e21d0324a6583159e14e42e57e56561abbf7bf68bef3d8f57b29e39c0",
+          "size": 96442143,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.15.linux-s390x.tar.gz",
+          "os": "linux",
+          "arch": "s390x",
+          "version": "go1.15.15",
+          "sha256": "eae39d97df6b758636d5427be0b083dbf9d49007b302825ac6c8645de039aaab",
+          "size": 101198583,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.15.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.15.15",
+          "sha256": "4036abdeb36c7db380d05f3ffd087b754c34df06b202ee381da77f4c5a44aa58",
+          "size": 118256667,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.15.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.15.15",
+          "sha256": "04d406e45da74f67151ca9b720899d18a8707d77e83f07ba11f9b099ced3fff1",
+          "size": 103342080,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.15.15.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.15.15",
+          "sha256": "7df7bf948dcc8ec0a3902e3301d17cbb5c2ebb01297d686ee2302e41f4ac6e10",
+          "size": 139064376,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.15.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.15.15",
+          "sha256": "c76656a253cc4c7a0ba7ae006cadc0bf2d6df7066acb8df84460eac94dc3a7d1",
+          "size": 120983552,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.15.14",
+        "stable": true,
+        "files": [
+         {
+          "filename": "go1.15.14.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.15.14",
+          "sha256": "60a4a5c48d63d0a13eca8849009b624629ff429c8bc5d1a6a8c3c4da9f34e70a",
+          "size": 23041432,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.15.14.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.15.14",
+          "sha256": "86b350467d5a09e717129d107072d242ec1cf9a1511acd46efe4ec825f6fe3dd",
+          "size": 122410213,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.14.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.15.14",
+          "sha256": "d74c12e2ddf51475968901ff06ae3b9d186a8a6660b01da123b75df4e6813480",
+          "size": 122781738,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.15.14.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.15.14",
+          "sha256": "520bd7eae9af3b769a5f4273f0b8e11951fe0376f179907e76e16bac880aff1b",
+          "size": 100312882,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.14.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.15.14",
+          "sha256": "9ac2f0d4e35cb1275c10c83cb86c4a24374f34682298ca2d6cfff86349d21859",
+          "size": 120998872,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.14.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.15.14",
+          "sha256": "0216746103b8da20b23f91a86795bcf72e12428b2d07dfd3279a14b070ceaa74",
+          "size": 100576048,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.14.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.15.14",
+          "sha256": "6f5410c113b803f437d7a1ee6f8f124100e536cc7361920f7e640fedf7add72d",
+          "size": 121105361,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.14.linux-arm64.tar.gz",
+          "os": "linux",
+          "arch": "arm64",
+          "version": "go1.15.14",
+          "sha256": "84e483d1ec7dae591f28f218485f8f67877412e24b8cea626bebf25b6d299c7f",
+          "size": 97716379,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.14.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.15.14",
+          "sha256": "a40fe975caf82daef311e22902eb4aeda1f0bd63a782c1ebd81911abed6c187b",
+          "size": 97986875,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.14.linux-ppc64le.tar.gz",
+          "os": "linux",
+          "arch": "ppc64le",
+          "version": "go1.15.14",
+          "sha256": "e17c29518940885d9f4a2e02f63c922d1c2537e8c2cb68617f0ec84aaf7635ca",
+          "size": 96425186,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.14.linux-s390x.tar.gz",
+          "os": "linux",
+          "arch": "s390x",
+          "version": "go1.15.14",
+          "sha256": "cfe577ab8f7d779e45b2cb3a93062f7e5552e509d6e0c3e389bbfd6001ee4fe4",
+          "size": 101195993,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.14.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.15.14",
+          "sha256": "2a920a672986599dd91cb8ed6a2e07ee4038495f1f5daca9a202fb1b05abae90",
+          "size": 118255090,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.14.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.15.14",
+          "sha256": "fe0318072a613259fd062d2b4676ab5ce36636796759d5379df0e0ea1395e819",
+          "size": 103342080,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.15.14.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.15.14",
+          "sha256": "88a77bebdd7276d0204f35e371aeaeb619f26b85d2ecf16f65cc713f4d49b9f7",
+          "size": 139063816,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.14.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.15.14",
+          "sha256": "cd030727ca202b6f47e745cf2b8b511cb63ca60a71ad441ee80dd225aceea4ae",
+          "size": 120963072,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.15.13",
+        "stable": true,
+        "files": [
+         {
+          "filename": "go1.15.13.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.15.13",
+          "sha256": "99069e7223479cce4553f84f874b9345f6f4045f27cf5089489b546da619a244",
+          "size": 23039791,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.15.13.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.15.13",
+          "sha256": "fc5415935430f75316374c918a20067d7a1883e4b0ffb33dc8c2ff34df6d55fe",
+          "size": 122395048,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.13.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.15.13",
+          "sha256": "253117d3a9d3fb584a8d6a7eeedf9946be9a38b1db694b8802f5772e21802bb3",
+          "size": 122770924,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.15.13.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.15.13",
+          "sha256": "d99f07567dc97166d5a7f9f857a64e4bf3641c02bc55e8ea5e24c7d4ca6f21a7",
+          "size": 100305233,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.13.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.15.13",
+          "sha256": "36f451d50785ebca3aa1945bdfa475ec82c58dcadb84d4f9f969fccc53588071",
+          "size": 120985474,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.13.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.15.13",
+          "sha256": "8df80ccbbd57b108ec43066925bf02aac47bc9e0236894dbd019f26944d27399",
+          "size": 100546337,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.13.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.15.13",
+          "sha256": "3d3beec5fc66659018e09f40abb7274b10794229ba7c1e8bdb7d8ca77b656a13",
+          "size": 121120420,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.13.linux-arm64.tar.gz",
+          "os": "linux",
+          "arch": "arm64",
+          "version": "go1.15.13",
+          "sha256": "f3989dca4dea5fbadfec253d7c24e4111773b203e677abb1f01e768a99cc14e6",
+          "size": 97712702,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.13.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.15.13",
+          "sha256": "00ff453f102c67ff6b790ba0cb10cecf73c8e8bbd9d913e5978ac8cc6323132f",
+          "size": 97990124,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.13.linux-ppc64le.tar.gz",
+          "os": "linux",
+          "arch": "ppc64le",
+          "version": "go1.15.13",
+          "sha256": "1a27f62d8812c28700e49cae46b9a378410e9eb735c79b1722cbe685f1c72528",
+          "size": 96397400,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.13.linux-s390x.tar.gz",
+          "os": "linux",
+          "arch": "s390x",
+          "version": "go1.15.13",
+          "sha256": "4448244965699706eff54d1f38917b8a896a27cf61a494f514818303c669a4b3",
+          "size": 101180575,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.13.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.15.13",
+          "sha256": "f6e7061495f43a6f26164d9430759a47382765fbf71c90ea714e275c9f4e99dc",
+          "size": 118245984,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.13.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.15.13",
+          "sha256": "50a717c7bccb9a3f03dc451bab85532f19513d77975c61717f1e8e6c997cb14d",
+          "size": 103325696,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.15.13.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.15.13",
+          "sha256": "d1cf76a11bbd5158715a3e3b6b7f0c623f5472f7c0e654c858913b74b09e7e81",
+          "size": 139053507,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.13.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.15.13",
+          "sha256": "151f8a71d0cba69dd889181dcece129d3bc5a15cd53251f09431de22a1119335",
+          "size": 120963072,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.15.12",
+        "stable": true,
+        "files": [
+         {
+          "filename": "go1.15.12.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.15.12",
+          "sha256": "1c6911937df4a277fa74e7b7efc3d08594498c4c4adc0b6c4ae3566137528091",
+          "size": 23035406,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.15.12.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.15.12",
+          "sha256": "05062d111062a5475f6f637018b09dc907bb6815bb156c26ebccf8d47ee35e2c",
+          "size": 122384700,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.12.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.15.12",
+          "sha256": "91cb985e63114633f91729a59f40ef43b67f70807b1d34325f58f8bdc0b0bf75",
+          "size": 122750009,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.15.12.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.15.12",
+          "sha256": "b8153343d1c52d65c86be70f3eed2756cc2e0048a419fd9510ae4b8b99773190",
+          "size": 100275394,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.12.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.15.12",
+          "sha256": "a63cca04ca822041219149402cf7b23c7f2d6b5d213329c1bf90cf9af62079d1",
+          "size": 120951529,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.12.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.15.12",
+          "sha256": "d186ccaa0080e301d35fa49a244877da6f08a1aeda3ed90438fee835538f7ece",
+          "size": 100558333,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.12.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.15.12",
+          "sha256": "bbdb935699e0b24d90e2451346da76121b2412d30930eabcd80907c230d098b7",
+          "size": 121101048,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.12.linux-arm64.tar.gz",
+          "os": "linux",
+          "arch": "arm64",
+          "version": "go1.15.12",
+          "sha256": "a10161e6f0389c45ecd810e114acaba967ea3a4def551fcbb0b1e270996103ed",
+          "size": 97728932,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.12.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.15.12",
+          "sha256": "6a20048f7061d06f590d869a5298e8c0ffc325e8faf0bb8b6a622ad007a53028",
+          "size": 97970507,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.12.linux-ppc64le.tar.gz",
+          "os": "linux",
+          "arch": "ppc64le",
+          "version": "go1.15.12",
+          "sha256": "c94c105e4e985b5675aa434845cced73a64bb050a8a96fa0e9b17dbea3ac6684",
+          "size": 96413509,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.12.linux-s390x.tar.gz",
+          "os": "linux",
+          "arch": "s390x",
+          "version": "go1.15.12",
+          "sha256": "9f1daa296e44ec0ce6b648e4e6d63210584b6c1ae2e46c77c8030b77514e8a8e",
+          "size": 101172120,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.12.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.15.12",
+          "sha256": "c31043ab926ae9b5b4a051baa85d19cfa24dac3b8255736824ec3a87aa6c9cf4",
+          "size": 118233658,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.12.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.15.12",
+          "sha256": "0c3c4e8c9f6b615f0e419da6569abdcff3cbbb6dfacfa3ae4a262b0b29338938",
+          "size": 103325696,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.15.12.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.15.12",
+          "sha256": "313e5ebc59b497319c4c3f9560322fcc20f7bc3b4e47494afc3b2d63a42fb2a5",
+          "size": 139035845,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.12.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.15.12",
+          "sha256": "0b9715ab043698181093ab11f57df403e5e39156f92a880f1ef68025eb7b55ed",
+          "size": 120942592,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.15.11",
+        "stable": true,
+        "files": [
+         {
+          "filename": "go1.15.11.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.15.11",
+          "sha256": "f25b2441d4c76cf63cde94d59bab237cc33e8a2a139040d904c8630f46d061e5",
+          "size": 23029946,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.15.11.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.15.11",
+          "sha256": "651c78408b2c047b7ccccb6b244c5de9eab927c87594ff6bd9540d43c9706671",
+          "size": 122357211,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.11.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.15.11",
+          "sha256": "18a143c21bba34d671fa952d66dc1221f0c39ac340ebbe6ef91770488e3eaf04",
+          "size": 122724893,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.15.11.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.15.11",
+          "sha256": "c9ac9e8e12b9a4639d8a164815d2ccab86f7c1534672c1d03933e7180d2ace5d",
+          "size": 100264795,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.11.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.15.11",
+          "sha256": "38fb5516e86934dc385d1b06433692034f38ed38117e8017e211a0efe55ed44e",
+          "size": 120942573,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.11.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.15.11",
+          "sha256": "2de51fc6873d8b688d7451cfc87443ef49404af98bbab9c8a36fb6c4bc95e4de",
+          "size": 100537845,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.11.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.15.11",
+          "sha256": "8825b72d74b14e82b54ba3697813772eb94add3abf70f021b6bdebe193ed01ec",
+          "size": 121079391,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.11.linux-arm64.tar.gz",
+          "os": "linux",
+          "arch": "arm64",
+          "version": "go1.15.11",
+          "sha256": "bfc8f07945296e97c6d28c7999d86b5cab51c7a87eb2b22ca6781c41a6bb6f2d",
+          "size": 97699191,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.11.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.15.11",
+          "sha256": "dba11ed018fc7b5774ca996c4bdb847f8f9535cdc4932eb09a43c390813af4c9",
+          "size": 97964010,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.11.linux-ppc64le.tar.gz",
+          "os": "linux",
+          "arch": "ppc64le",
+          "version": "go1.15.11",
+          "sha256": "4916ef0fc4c40db2dcc503a3473b325ed21d100cc77f1cc7e0a3aede19eec628",
+          "size": 96409553,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.11.linux-s390x.tar.gz",
+          "os": "linux",
+          "arch": "s390x",
+          "version": "go1.15.11",
+          "sha256": "2fb25504fa525e24dbba7e8e7fa2d91c42c66272dc176d5270dec77099124c75",
+          "size": 101167488,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.11.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.15.11",
+          "sha256": "b0a64a2a2dedefd1559acf866e393c8e00294dbde113875ee9d8cf3561886123",
+          "size": 118224267,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.11.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.15.11",
+          "sha256": "3224c9ea3ddfdb4eb56c6c5fc761fd3bb2d61430ac589fb147d77df50f662ffe",
+          "size": 103313408,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.15.11.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.15.11",
+          "sha256": "56f63de17cd739287de6d9f3cfdad3b781ad3e4a18aae20ece994ee97c1819fd",
+          "size": 139024980,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.11.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.15.11",
+          "sha256": "148667008ebd74f51372140a92ab192ea2bc20329d64ab79349e8d908938847f",
+          "size": 120930304,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.15.10",
+        "stable": true,
+        "files": [
+         {
+          "filename": "go1.15.10.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.15.10",
+          "sha256": "c1dbca6e0910b41d61a95bf9878f6d6e93d15d884c226b91d9d4b1113c10dd65",
+          "size": 23021993,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.15.10.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.15.10",
+          "sha256": "19648b2495eade4c77797c789cd437e81ae575d84594f7c7f63d25c6ed24865e",
+          "size": 122358976,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.10.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.15.10",
+          "sha256": "da78f2cbc0aa9f8adb2ed940dfa2b1217728e8672afca42f27110d9fe780ee3c",
+          "size": 122720833,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.15.10.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.15.10",
+          "sha256": "3b86b71075e258f0f09ea025317fe78ed0e49d9da59acb5e29e67eaea835166e",
+          "size": 100245123,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.10.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.15.10",
+          "sha256": "eab5abfc8a1794d921b39da6e61a7638a7aaab401a645231f38238c7eaadc8b1",
+          "size": 120945944,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.10.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.15.10",
+          "sha256": "69a29473c9e8eded5b5885a45773e4f1b9661383ce577199c4c70efe4c67bc59",
+          "size": 100540945,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.10.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.15.10",
+          "sha256": "4aa1267517df32f2bf1cc3d55dfc27d0c6b2c2b0989449c96dd19273ccca051d",
+          "size": 121069320,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.10.linux-arm64.tar.gz",
+          "os": "linux",
+          "arch": "arm64",
+          "version": "go1.15.10",
+          "sha256": "ca3f3e84d863d8e758bfaab65430b12b6cff8f5a5648139245321d3401da64a7",
+          "size": 97699860,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.10.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.15.10",
+          "sha256": "10739f7a87544acca49c9f1c025ae1821ce83601228a968bd7102357ae89887b",
+          "size": 97945905,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.10.linux-ppc64le.tar.gz",
+          "os": "linux",
+          "arch": "ppc64le",
+          "version": "go1.15.10",
+          "sha256": "49128af704c37a356b1d14d814e4cf64218a8c6cabb22249e0c0068b35f710d3",
+          "size": 96390789,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.10.linux-s390x.tar.gz",
+          "os": "linux",
+          "arch": "s390x",
+          "version": "go1.15.10",
+          "sha256": "230e0e50fe0df0ba380804c02f1d88a801c6dee38582c4a9502e79dc744c7bb0",
+          "size": 101144833,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.10.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.15.10",
+          "sha256": "b76f65ac809775d13d06f5c7d9daba8a8855cda3cac51297e925c4dbfa965070",
+          "size": 118212768,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.10.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.15.10",
+          "sha256": "69143a922c59026691a79062ab61ae8d44babcb7f90de2148eb71eff4acd3999",
+          "size": 103313408,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.15.10.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.15.10",
+          "sha256": "ba30d211e96d57ce2becf17fe9ebe1d958eba29384c5aeb1e99f9209b44dd7c2",
+          "size": 139013975,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.10.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.15.10",
+          "sha256": "187a8bdd1b138ab16d6048108a0ffa793278a57a4ec57f8cef5e8887a3fd4363",
+          "size": 120942592,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.15.9",
+        "stable": true,
+        "files": [
+         {
+          "filename": "go1.15.9.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.15.9",
+          "sha256": "90983b9c84a92417337dc1942ff066fc8b3a69733b8b5493fd0b9b9db1ead60f",
+          "size": 23019739,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.15.9.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.15.9",
+          "sha256": "1a7b20801933050490a6114392b6c842f3c4774bb43e15240c1faf98a01d645a",
+          "size": 122354600,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.9.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.15.9",
+          "sha256": "7bce1b7b374d84474dbb7a242f01935e56db3f1c97901fcc70ad733b2e530aa3",
+          "size": 122718740,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.15.9.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.15.9",
+          "sha256": "59ae769d9331c8339d2e2606260beb34030e4e9d5b3b0a727b225ef8615f7fef",
+          "size": 100240798,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.9.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.15.9",
+          "sha256": "fb094473efce8df290cf0a78dba8dbf5c76462851eeba3efb5f579746d6117e3",
+          "size": 120939644,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.9.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.15.9",
+          "sha256": "469868ac51391b84e153d09c82dacf2c75bf81b96dc13c9bee15fdd50b3406de",
+          "size": 100525550,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.9.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.15.9",
+          "sha256": "a55f3e75bc1098045851d40ea74f9d77efc7958e9af85131a96ca387d38b1834",
+          "size": 121068907,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.9.linux-arm64.tar.gz",
+          "os": "linux",
+          "arch": "arm64",
+          "version": "go1.15.9",
+          "sha256": "8ea5f3718abde696b4762882b5a9753a8ec148c9b32e3d37e5f2e52a1f9b12ca",
+          "size": 97697797,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.9.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.15.9",
+          "sha256": "9dac54ad8afe282bd18b09d6ed0fad3b663187f914db2e43ee1b6968135ef01d",
+          "size": 97943842,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.9.linux-ppc64le.tar.gz",
+          "os": "linux",
+          "arch": "ppc64le",
+          "version": "go1.15.9",
+          "sha256": "dc30dff3b549b891f0326029dc3823e76af64f9e8352134b51c8cffbf7e567b9",
+          "size": 96376700,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.9.linux-s390x.tar.gz",
+          "os": "linux",
+          "arch": "s390x",
+          "version": "go1.15.9",
+          "sha256": "f16f3dcea7d0fbe3182622f596ae63e63cc5ad4a26545b65660dbb44d8c05614",
+          "size": 101130411,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.9.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.15.9",
+          "sha256": "27e623d4dd3daf36ad0e90616b8161ae4fbfa2ff6c2541671dc31bb1b90c9abd",
+          "size": 118206264,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.9.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.15.9",
+          "sha256": "60252583eccf6df62a3e5bef365d5148b52a9241f022d46b2fd935ee82b72cca",
+          "size": 103309312,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.15.9.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.15.9",
+          "sha256": "daf5c44fb8d6ddd001a0d1eca3d562167101f3d18129c9c935728449036dd79c",
+          "size": 139007200,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.9.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.15.9",
+          "sha256": "d9547445a5aee95108ec0f88a7a6ceec5ed51560054df085ac803beba9059aa0",
+          "size": 120930304,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.15.8",
+        "stable": true,
+        "files": [
+         {
+          "filename": "go1.15.8.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.15.8",
+          "sha256": "540c0ab7781084d124991321ed1458e479982de94454a98afab6acadf38497c2",
+          "size": 23018628,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.15.8.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.15.8",
+          "sha256": "7df8977d3befd2ec41479abed1c93aac93cb320dcbe4808950d28948911da854",
+          "size": 122353388,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.8.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.15.8",
+          "sha256": "26fd5e7b7422f00116aaccbc74b78475e13497669220dcf96e135d871389e6e8",
+          "size": 122705614,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.15.8.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.15.8",
+          "sha256": "46fbf0fe03910569113989bf608e56f847df685efccdcee29d8ab3b9752211f8",
+          "size": 100239248,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.8.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.15.8",
+          "sha256": "ec5b0e690593f8d6e1964221b1a95b2a3efdedcfd3562f4113cd1c0b6180a5ee",
+          "size": 120937877,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.8.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.15.8",
+          "sha256": "a0cc9df6d04f89af8396278d171087894a453a03a950b0f60a4ac18b480f758f",
+          "size": 100524880,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.8.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.15.8",
+          "sha256": "d3379c32a90fdf9382166f8f48034c459a8cc433730bc9476d39d9082c94583b",
+          "size": 121066822,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.8.linux-arm64.tar.gz",
+          "os": "linux",
+          "arch": "arm64",
+          "version": "go1.15.8",
+          "sha256": "0e31ea4bf53496b0f0809730520dee98c0ae5c530f3701a19df0ba0a327bf3d2",
+          "size": 97697452,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.8.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.15.8",
+          "sha256": "708c398cb9e5029cfd5b654370978bf0e797d4d4a71153c06c7378db7e249a53",
+          "size": 97941770,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.8.linux-ppc64le.tar.gz",
+          "os": "linux",
+          "arch": "ppc64le",
+          "version": "go1.15.8",
+          "sha256": "c6ddeab22b23ee33f5e8f06f9667e2092f48dbc6d5db553a66f7fe21da73fbfa",
+          "size": 96378870,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.8.linux-s390x.tar.gz",
+          "os": "linux",
+          "arch": "s390x",
+          "version": "go1.15.8",
+          "sha256": "ba922f54fe99dee3246705bacbfac27fa88375439025429297aa1e9caf3f2297",
+          "size": 101130165,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.8.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.15.8",
+          "sha256": "091cf23efe75e1e039e10808878d56467f12a28edb0de935ce5aab31aab5d52c",
+          "size": 118206126,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.8.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.15.8",
+          "sha256": "80e07b56a3bbc22e4970c3c7232cdf97875c79f30120d9c202fc68590001455a",
+          "size": 103292928,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.15.8.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.15.8",
+          "sha256": "ef05b7141d3c217fb076f0e27249e144296234df96ead8751c0b76784079df97",
+          "size": 139005264,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15.8.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.15.8",
+          "sha256": "edc1bd458f090ac4823ec79181b350bd5446073b4432acaf2b326c85415d7daa",
+          "size": 120930304,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
         "version": "go1.15.7",
         "stable": true,
         "files": [
@@ -147,147 +2724,6 @@ interactions:
           "version": "go1.15.7",
           "sha256": "548e73797f07c8f7dcd4e419f396a41702ab68d1bc82ff637587b94bcdc9a462",
           "size": 120938496,
-          "kind": "installer"
-         }
-        ]
-       },
-       {
-        "version": "go1.14.14",
-        "stable": true,
-        "files": [
-         {
-          "filename": "go1.14.14.src.tar.gz",
-          "os": "",
-          "arch": "",
-          "version": "go1.14.14",
-          "sha256": "6204bf32f58fae0853f47f1bd0c51d9e0ac11f1ffb406bed07a0a8b016c8a76f",
-          "size": 22557733,
-          "kind": "source"
-         },
-         {
-          "filename": "go1.14.14.darwin-amd64.tar.gz",
-          "os": "darwin",
-          "arch": "amd64",
-          "version": "go1.14.14",
-          "sha256": "50a64d6a7ef85510321f0cbcd64e7c72f7e82e27c22f0ba475b9b6b6213f136e",
-          "size": 125466649,
-          "kind": "archive"
-         },
-         {
-          "filename": "go1.14.14.darwin-amd64.pkg",
-          "os": "darwin",
-          "arch": "amd64",
-          "version": "go1.14.14",
-          "sha256": "905ef1af25124d64a1a8d22163e4845b013b1d34a4306a8ac045fda2385ca01c",
-          "size": 125829710,
-          "kind": "installer"
-         },
-         {
-          "filename": "go1.14.14.freebsd-386.tar.gz",
-          "os": "freebsd",
-          "arch": "386",
-          "version": "go1.14.14",
-          "sha256": "7865dffe01499e5e26a40ebc15e068e683e64a2f2edff7440fc9802b02f122bb",
-          "size": 104993214,
-          "kind": "archive"
-         },
-         {
-          "filename": "go1.14.14.freebsd-amd64.tar.gz",
-          "os": "freebsd",
-          "arch": "amd64",
-          "version": "go1.14.14",
-          "sha256": "a4fab9549523eefe4cdb4d1334144cb51825db2cfe7993497773f5c9349f6647",
-          "size": 124048745,
-          "kind": "archive"
-         },
-         {
-          "filename": "go1.14.14.linux-386.tar.gz",
-          "os": "linux",
-          "arch": "386",
-          "version": "go1.14.14",
-          "sha256": "b08e088ba99134035782c71aeaf139f36d2306eb88eddc22c1278b8b446f157e",
-          "size": 105189162,
-          "kind": "archive"
-         },
-         {
-          "filename": "go1.14.14.linux-amd64.tar.gz",
-          "os": "linux",
-          "arch": "amd64",
-          "version": "go1.14.14",
-          "sha256": "6f1354c9040d65d1622b451f43c324c1e5197aa9242d00c5a117d0e2625f3e0d",
-          "size": 124075124,
-          "kind": "archive"
-         },
-         {
-          "filename": "go1.14.14.linux-arm64.tar.gz",
-          "os": "linux",
-          "arch": "arm64",
-          "version": "go1.14.14",
-          "sha256": "511d764197121f212d130724afb9c296f0cb4a22424e5ae956a5cc043b0f4a29",
-          "size": 101366896,
-          "kind": "archive"
-         },
-         {
-          "filename": "go1.14.14.linux-armv6l.tar.gz",
-          "os": "linux",
-          "arch": "armv6l",
-          "version": "go1.14.14",
-          "sha256": "e4d614c23b77a367becaeac3032cf4911793363a33efa299d29440be3d66234b",
-          "size": 102125042,
-          "kind": "archive"
-         },
-         {
-          "filename": "go1.14.14.linux-ppc64le.tar.gz",
-          "os": "linux",
-          "arch": "ppc64le",
-          "version": "go1.14.14",
-          "sha256": "f24eddfac754b48d9c28a459f0e4fc5af8f037dac0e9b3159b9bb98b6b1ab88c",
-          "size": 100266873,
-          "kind": "archive"
-         },
-         {
-          "filename": "go1.14.14.linux-s390x.tar.gz",
-          "os": "linux",
-          "arch": "s390x",
-          "version": "go1.14.14",
-          "sha256": "fcd84558e80257d3c308342964c10c1de8bd1c031c579bb02c5c07bf86fd86d7",
-          "size": 105693139,
-          "kind": "archive"
-         },
-         {
-          "filename": "go1.14.14.windows-386.zip",
-          "os": "windows",
-          "arch": "386",
-          "version": "go1.14.14",
-          "sha256": "60ebb9f44549f4827bd29bab822ad881cec6d0f83fff49bda7ad20e69b7b4e7b",
-          "size": 118421154,
-          "kind": "archive"
-         },
-         {
-          "filename": "go1.14.14.windows-386.msi",
-          "os": "windows",
-          "arch": "386",
-          "version": "go1.14.14",
-          "sha256": "5f4b9618c3216e2f1156fb05e78b5b6ec55db6fb0d44f9c6e331878bdafe7118",
-          "size": 103944192,
-          "kind": "installer"
-         },
-         {
-          "filename": "go1.14.14.windows-amd64.zip",
-          "os": "windows",
-          "arch": "amd64",
-          "version": "go1.14.14",
-          "sha256": "88e6be798902d802481b83015e23f6e587cbe0e58766dfa7959d1032865f6bab",
-          "size": 138226134,
-          "kind": "archive"
-         },
-         {
-          "filename": "go1.14.14.windows-amd64.msi",
-          "os": "windows",
-          "arch": "amd64",
-          "version": "go1.14.14",
-          "sha256": "84e402cc635429688907d37f97aea23ab050a3fe5cf8fc37cf338f9c75d53b3e",
-          "size": 121106432,
           "kind": "installer"
          }
         ]
@@ -1275,6 +3711,288 @@ interactions:
           "version": "go1.15",
           "sha256": "02944771ca3cffe7bcda85c6ec16eb6dac94e4b1c877cceb610ecab92d4e0a32",
           "size": 121090048,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.14.15",
+        "stable": true,
+        "files": [
+         {
+          "filename": "go1.14.15.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.14.15",
+          "sha256": "7ed13b2209e54a451835997f78035530b331c5b6943cdcd68a3d815fdc009149",
+          "size": 22557340,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.14.15.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.14.15",
+          "sha256": "cc116e7522d1d1bcb606ce413555c4f2d5c86c0c8d5e5074a0d57b303d8edb50",
+          "size": 125507930,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.14.15.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.14.15",
+          "sha256": "692f2f2d02725cf093d1efa51b2fb5b8d6adf02708f964a1b6229f7fdbacae57",
+          "size": 125863660,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.14.15.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.14.15",
+          "sha256": "4d8eb68aa9bdc1d13cebe8884c6bf4f9cc0b8baea383620113ff6a2ac17c8d63",
+          "size": 105026782,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.14.15.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.14.15",
+          "sha256": "06b355212b788e348369e1d09bb55aed73da4b3569af5a5f8801dd88182df99f",
+          "size": 124090347,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.14.15.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.14.15",
+          "sha256": "cab962eaf954378bbb5b24f703baf3b471e9690a109082dd688593fbb6f9008e",
+          "size": 105235796,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.14.15.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.14.15",
+          "sha256": "c64a57b374a81f7cf1408d2c410a28c6f142414f1ffa9d1062de1d653b0ae0d6",
+          "size": 124135233,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.14.15.linux-arm64.tar.gz",
+          "os": "linux",
+          "arch": "arm64",
+          "version": "go1.14.15",
+          "sha256": "4d964166a189c22032521c63935437c304bb7f01673b196898cff525897a1c27",
+          "size": 101413983,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.14.15.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.14.15",
+          "sha256": "a63960d9b9c14954e299ffe060c0574ffb91ab810837da5941853b664d0652da",
+          "size": 102148192,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.14.15.linux-ppc64le.tar.gz",
+          "os": "linux",
+          "arch": "ppc64le",
+          "version": "go1.14.15",
+          "sha256": "64d82004270bcd00948dbed9f1a123ef844ceb7633e6a87a5ca7ef8bdf59cfc1",
+          "size": 100290977,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.14.15.linux-s390x.tar.gz",
+          "os": "linux",
+          "arch": "s390x",
+          "version": "go1.14.15",
+          "sha256": "8e121c947ec531628d37ad0292623f22c8f9fecac6067192b5cce34b36cedd79",
+          "size": 105703775,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.14.15.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.14.15",
+          "sha256": "6d990df3f60fc120d7e2ce7ffcaad102c1d595fb631ad2bd097217458004cd30",
+          "size": 118462703,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.14.15.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.14.15",
+          "sha256": "13345fbb611f77df96734fd80b5638493a37b16169589c2ab961ffd09ae8bc75",
+          "size": 103972864,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.14.15.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.14.15",
+          "sha256": "189bc564d537d86f80c70757ee4c29fb1c2c6e8d05bb6de1242a03a96ac850cb",
+          "size": 138273428,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.14.15.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.14.15",
+          "sha256": "504a2eecd0b2075efa412208cc1578101828ab00775ee372d311c0d512172c12",
+          "size": 121118720,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.14.14",
+        "stable": true,
+        "files": [
+         {
+          "filename": "go1.14.14.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.14.14",
+          "sha256": "6204bf32f58fae0853f47f1bd0c51d9e0ac11f1ffb406bed07a0a8b016c8a76f",
+          "size": 22557733,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.14.14.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.14.14",
+          "sha256": "50a64d6a7ef85510321f0cbcd64e7c72f7e82e27c22f0ba475b9b6b6213f136e",
+          "size": 125466649,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.14.14.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.14.14",
+          "sha256": "905ef1af25124d64a1a8d22163e4845b013b1d34a4306a8ac045fda2385ca01c",
+          "size": 125829710,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.14.14.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.14.14",
+          "sha256": "7865dffe01499e5e26a40ebc15e068e683e64a2f2edff7440fc9802b02f122bb",
+          "size": 104993214,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.14.14.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.14.14",
+          "sha256": "a4fab9549523eefe4cdb4d1334144cb51825db2cfe7993497773f5c9349f6647",
+          "size": 124048745,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.14.14.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.14.14",
+          "sha256": "b08e088ba99134035782c71aeaf139f36d2306eb88eddc22c1278b8b446f157e",
+          "size": 105189162,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.14.14.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.14.14",
+          "sha256": "6f1354c9040d65d1622b451f43c324c1e5197aa9242d00c5a117d0e2625f3e0d",
+          "size": 124075124,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.14.14.linux-arm64.tar.gz",
+          "os": "linux",
+          "arch": "arm64",
+          "version": "go1.14.14",
+          "sha256": "511d764197121f212d130724afb9c296f0cb4a22424e5ae956a5cc043b0f4a29",
+          "size": 101366896,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.14.14.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.14.14",
+          "sha256": "e4d614c23b77a367becaeac3032cf4911793363a33efa299d29440be3d66234b",
+          "size": 102125042,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.14.14.linux-ppc64le.tar.gz",
+          "os": "linux",
+          "arch": "ppc64le",
+          "version": "go1.14.14",
+          "sha256": "f24eddfac754b48d9c28a459f0e4fc5af8f037dac0e9b3159b9bb98b6b1ab88c",
+          "size": 100266873,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.14.14.linux-s390x.tar.gz",
+          "os": "linux",
+          "arch": "s390x",
+          "version": "go1.14.14",
+          "sha256": "fcd84558e80257d3c308342964c10c1de8bd1c031c579bb02c5c07bf86fd86d7",
+          "size": 105693139,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.14.14.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.14.14",
+          "sha256": "60ebb9f44549f4827bd29bab822ad881cec6d0f83fff49bda7ad20e69b7b4e7b",
+          "size": 118421154,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.14.14.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.14.14",
+          "sha256": "5f4b9618c3216e2f1156fb05e78b5b6ec55db6fb0d44f9c6e331878bdafe7118",
+          "size": 103944192,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.14.14.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.14.14",
+          "sha256": "88e6be798902d802481b83015e23f6e587cbe0e58766dfa7959d1032865f6bab",
+          "size": 138226134,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.14.14.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.14.14",
+          "sha256": "84e402cc635429688907d37f97aea23ab050a3fe5cf8fc37cf338f9c75d53b3e",
+          "size": 121106432,
           "kind": "installer"
          }
         ]
@@ -16691,6 +19409,537 @@ interactions:
         ]
        },
        {
+        "version": "go1.17rc2",
+        "stable": false,
+        "files": [
+         {
+          "filename": "go1.17rc2.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.17rc2",
+          "sha256": "5ab21d75552390c63087518e4eba2972fb009aea97ff2bcc42dff264c5f46fe9",
+          "size": 22173399,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.17rc2.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.17rc2",
+          "sha256": "8abf0b17d6a0664e53ea7e1aecb649e2378732d2d97e8a292c27e6aae711c6c9",
+          "size": 135941472,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.17rc2.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.17rc2",
+          "sha256": "717aba0ed79d5a75741ea52536448d2b8bfdad6361863c8973fe76cdf75fbf29",
+          "size": 136368876,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.17rc2.darwin-arm64.tar.gz",
+          "os": "darwin",
+          "arch": "arm64",
+          "version": "go1.17rc2",
+          "sha256": "fb8954dc8172bfabb8c22125a994a04278be554f15a1cb26ff2595841d9c1ba1",
+          "size": 129418220,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.17rc2.darwin-arm64.pkg",
+          "os": "darwin",
+          "arch": "arm64",
+          "version": "go1.17rc2",
+          "sha256": "9c567623e72a0ad46e660c4eeb30571b0ff6d224b4f6bc39cc2005194be4bd13",
+          "size": 129822348,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.17rc2.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.17rc2",
+          "sha256": "cffffb5dc4937d1f6728cc9a88aa33ade059040a3b3856eca8e65d31df3e3b49",
+          "size": 105451932,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.17rc2.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.17rc2",
+          "sha256": "48b36ed9618b81d4d59acdec3bcf56f18e97173c46dd5efa875ad7b03da61330",
+          "size": 133573845,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.17rc2.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.17rc2",
+          "sha256": "273fd4647d2311e3044d3d937eedbee91477317d867b6c81636fdc0a9ba7f947",
+          "size": 105597158,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.17rc2.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.17rc2",
+          "sha256": "328235edc7c7d2a51d6c6cb4d7ff97e97357654ef9e1098b9a4603a9d278ad04",
+          "size": 134787799,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.17rc2.linux-arm64.tar.gz",
+          "os": "linux",
+          "arch": "arm64",
+          "version": "go1.17rc2",
+          "sha256": "4e1b335c53bf28cd20c5f7f2f7e79187b93e71c1d027448e313097785efb673d",
+          "size": 102596537,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.17rc2.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.17rc2",
+          "sha256": "4820fcd80b47e7d7dc1f15343c4fb59e66183cef9dadb3d3ac10f82615ad2141",
+          "size": 103051051,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.17rc2.linux-ppc64le.tar.gz",
+          "os": "linux",
+          "arch": "ppc64le",
+          "version": "go1.17rc2",
+          "sha256": "57fd15f97e4fccc3227d07423baca2b3e44fb2c1b12a35f8cda8a453867ca1b6",
+          "size": 100996440,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.17rc2.linux-s390x.tar.gz",
+          "os": "linux",
+          "arch": "s390x",
+          "version": "go1.17rc2",
+          "sha256": "be3a78ae162eac193fc66b0ed50f56c75c5a1506c6b631a1f2af3d4e700816fe",
+          "size": 105766101,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.17rc2.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.17rc2",
+          "sha256": "c74a563ef59a8bdd0ee96d03c5dc4db21bf077d1f89dc2056d1c6d99de6ffed8",
+          "size": 120966902,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.17rc2.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.17rc2",
+          "sha256": "e2d086565ca7d3100e15673755f9cfc14f428958d74d199b204de8bee6c7fc6d",
+          "size": 105431040,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.17rc2.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.17rc2",
+          "sha256": "4b4d5aa3a393c3d633286053ffad08a2b2ae558a7ee09116014f42fccb12c753",
+          "size": 150362110,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.17rc2.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.17rc2",
+          "sha256": "07607ea299bb3214a4886661c75f24510065d7fc6f14bf8af3aba85286034458",
+          "size": 130314240,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.17rc2.windows-arm64.zip",
+          "os": "windows",
+          "arch": "arm64",
+          "version": "go1.17rc2",
+          "sha256": "4de539dd74ca86cde5c2a21671ab88e301a5d7e63af30aedbf03cc7a2776cbd1",
+          "size": 116660997,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.17rc2.windows-arm64.msi",
+          "os": "windows",
+          "arch": "arm64",
+          "version": "go1.17rc2",
+          "sha256": "2bc039558f27d601045903c263ed427a94bf673d37e8e4894b65f9dec3b40db7",
+          "size": 101986304,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.17rc1",
+        "stable": false,
+        "files": [
+         {
+          "filename": "go1.17rc1.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.17rc1",
+          "sha256": "0d63be0f3abc79d35efcb60dfce4445e64bb1ea194edcfd9783a76316b7e85e2",
+          "size": 22166943,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.17rc1.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.17rc1",
+          "sha256": "bc9971349a154e8c96e9488ea8f60f8d859725275a11562e38f4a7314df52200",
+          "size": 135933957,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.17rc1.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.17rc1",
+          "sha256": "206a9c7b7f29d959835e563264c25a5e114c9090fdae2e1959ca0f49d4246c52",
+          "size": 136353150,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.17rc1.darwin-arm64.tar.gz",
+          "os": "darwin",
+          "arch": "arm64",
+          "version": "go1.17rc1",
+          "sha256": "39dcd3fe8443bfa42f17defaf5bc95944657e9a30f79c695d17e6738012110ff",
+          "size": 129409901,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.17rc1.darwin-arm64.pkg",
+          "os": "darwin",
+          "arch": "arm64",
+          "version": "go1.17rc1",
+          "sha256": "4e654054c1da8d9fa391fc2fa5e0bbfc406796f09f19937578b84388a2d53f51",
+          "size": 129821642,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.17rc1.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.17rc1",
+          "sha256": "0e0ffff26c63f8cc9ffcf8ae9417c569e4c14b82b0e10abb6a3a422e5b191889",
+          "size": 105471772,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.17rc1.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.17rc1",
+          "sha256": "d241d523f22744a244a19539d2c724130af6bed23e1ba034a4e8f0624af0f9b3",
+          "size": 133570506,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.17rc1.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.17rc1",
+          "sha256": "e9b78a4bd98165b86bb887643f58cc0464cc7ff7fae12516fc43114809c71e07",
+          "size": 105607045,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.17rc1.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.17rc1",
+          "sha256": "bfbd3881a01ca3826777b1c40f241acacd45b14730d373259cd673d74e15e534",
+          "size": 134784935,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.17rc1.linux-arm64.tar.gz",
+          "os": "linux",
+          "arch": "arm64",
+          "version": "go1.17rc1",
+          "sha256": "7498e426ce814a94a1d271d6bb80b9a2cf8c77ec49df531c57bd7a9ff82cfa4e",
+          "size": 102613909,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.17rc1.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.17rc1",
+          "sha256": "1fd5c3733d6fab5ebcb3ca6ae2b478d370bb0638ba3966284ed7e7aa97acfc8a",
+          "size": 103075213,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.17rc1.linux-ppc64le.tar.gz",
+          "os": "linux",
+          "arch": "ppc64le",
+          "version": "go1.17rc1",
+          "sha256": "d3aec884d6cbb8504bb25591a780759dd0ea5d9ede2a5e6af1dfe210df0a60f1",
+          "size": 101008810,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.17rc1.linux-s390x.tar.gz",
+          "os": "linux",
+          "arch": "s390x",
+          "version": "go1.17rc1",
+          "sha256": "23318ad51bd3d164aed307b500b9e89174e7df425a0cd03e619b65bbd65d6b19",
+          "size": 105762957,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.17rc1.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.17rc1",
+          "sha256": "41017a302209625d5b38ba472dc8bf19944233fa4fdb2e2ab619d16743156621",
+          "size": 120962859,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.17rc1.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.17rc1",
+          "sha256": "a845a852d6b94ddcc02bb09430694a3d706ed0be98116c578120203f4ddd940e",
+          "size": 105435136,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.17rc1.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.17rc1",
+          "sha256": "9f5303e420fdaf4ddea09a627726dec55914e151be473f7d206247f93732a976",
+          "size": 150357620,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.17rc1.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.17rc1",
+          "sha256": "7b907dad5e65c709743b336106ede3a81262cfcfc912338722a1385f38849d89",
+          "size": 130297856,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.17rc1.windows-arm64.zip",
+          "os": "windows",
+          "arch": "arm64",
+          "version": "go1.17rc1",
+          "sha256": "faf7d3ac48b8ff292c7f772ca4977131a2302e31cb336488f6deef9d159616bf",
+          "size": 116665489,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.17rc1.windows-arm64.msi",
+          "os": "windows",
+          "arch": "arm64",
+          "version": "go1.17rc1",
+          "sha256": "5a92a569bf6234f415c24d0670a7cc5d8c60aea7abbec42a33a7c8725eb30543",
+          "size": 101969920,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.17beta1",
+        "stable": false,
+        "files": [
+         {
+          "filename": "go1.17beta1.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.17beta1",
+          "sha256": "02b8973725f9bc545955865576e8c8f6ca672312f69fd9e5549c25b0ce1d75f0",
+          "size": 22145306,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.17beta1.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.17beta1",
+          "sha256": "50046983ccd66180d1b6fbf39b4e5acb61dd08f1b53803661d86b60ba304bf80",
+          "size": 135610703,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.17beta1.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.17beta1",
+          "sha256": "370ad2ed9509b3f1cc8fcb8c151bff631084ec731f75849074518ba8c94af170",
+          "size": 136039278,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.17beta1.darwin-arm64.tar.gz",
+          "os": "darwin",
+          "arch": "arm64",
+          "version": "go1.17beta1",
+          "sha256": "14f477d7c8d6ced879318257a57fc5f39e23aa4502a0f595c0103039e0a4abc0",
+          "size": 129346226,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.17beta1.darwin-arm64.pkg",
+          "os": "darwin",
+          "arch": "arm64",
+          "version": "go1.17beta1",
+          "sha256": "315626044e6eff32115e29652aadedb203870784560c84eeeaf37bc7353f590c",
+          "size": 129749624,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.17beta1.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.17beta1",
+          "sha256": "d3ea61c33445c6f9cfa5543b199badf6a9953cfb8fa825986fd6f2cba4355e63",
+          "size": 105392130,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.17beta1.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.17beta1",
+          "sha256": "7673f5b0478ac7cac0bfa97ad8757fdba1c3630378c5b667a6013b339c7d08aa",
+          "size": 133448653,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.17beta1.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.17beta1",
+          "sha256": "cebbf75985ba7e6f1a5b137916a6019685d52ecf36c262092ffc3f714cd85974",
+          "size": 105525787,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.17beta1.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.17beta1",
+          "sha256": "a479681705b65971f9db079bfce53c4393bfa241d952eb09de88fb40677d3c4c",
+          "size": 134470397,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.17beta1.linux-arm64.tar.gz",
+          "os": "linux",
+          "arch": "arm64",
+          "version": "go1.17beta1",
+          "sha256": "ede56f79c5061146929ab4a128e8ee7bc713d141e87b3df4e0aa670938e128b3",
+          "size": 102531523,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.17beta1.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.17beta1",
+          "sha256": "f4ab69c75a1f9e43b07ca9a0bfdf68ca1e2b0b51d4ebfb8c79f60ed14629f4e6",
+          "size": 102996695,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.17beta1.linux-ppc64le.tar.gz",
+          "os": "linux",
+          "arch": "ppc64le",
+          "version": "go1.17beta1",
+          "sha256": "0a6e5034fcbd4b38642b56841a042135aec1e87f61258d2d70aafc0a667bdd11",
+          "size": 100936272,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.17beta1.linux-s390x.tar.gz",
+          "os": "linux",
+          "arch": "s390x",
+          "version": "go1.17beta1",
+          "sha256": "3501d139a9433775001730f1d9c3fb60d7b93b969fe16bd80fc7387a3d5259b1",
+          "size": 105676990,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.17beta1.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.17beta1",
+          "sha256": "da7ca16de51e8fbc9a982216361959d245fd83479d602de214667e8319279c6b",
+          "size": 120868238,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.17beta1.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.17beta1",
+          "sha256": "8f36d2dcce8434051ba523218ec0252ea0a1fa9c0536bede117dc01baf9ebd2c",
+          "size": 105365504,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.17beta1.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.17beta1",
+          "sha256": "7a2154c1a35d3e6441e649c81a30817f8f669aea9029f5d1010e1a264dfd264f",
+          "size": 150043607,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.17beta1.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.17beta1",
+          "sha256": "d379f2f865c420a8825a707a9a0acc9a9aaf63cedcab5da8cb8095dc18dc680a",
+          "size": 130043904,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.17beta1.windows-arm64.zip",
+          "os": "windows",
+          "arch": "arm64",
+          "version": "go1.17beta1",
+          "sha256": "f0b6a3ccdf5b3e1ec72f5dabf7e9659f371e0faa2a5290c23afa6f5eae7a90a8",
+          "size": 116587377,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.17beta1.windows-arm64.msi",
+          "os": "windows",
+          "arch": "arm64",
+          "version": "go1.17beta1",
+          "sha256": "bf0f9293d513ad6cb3a203e6b1561c5fcbb0073f0910c03de491bceef7cb086d",
+          "size": 101920768,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
         "version": "go1.16rc1",
         "stable": false,
         "files": [
@@ -16848,6 +20097,6861 @@ interactions:
           "kind": "installer"
          }
         ]
+       },
+       {
+        "version": "go1.16beta1",
+        "stable": false,
+        "files": [
+         {
+          "filename": "go1.16beta1.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.16beta1",
+          "sha256": "48e032c8cf71af4dc8119a29ee829c4fbd5265e32fd012564d4a70bb207695c1",
+          "size": 23380831,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.16beta1.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.16beta1",
+          "sha256": "c3518be5a17c7df746e2596e2ea310cd56348e05454f2bfbb25c5e84708dc2e2",
+          "size": 132370535,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16beta1.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.16beta1",
+          "sha256": "f8c7d8016533a438feca33e2fbba39f1bac9f00b9787d01bfe8aa2e93aa65074",
+          "size": 132734236,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.16beta1.darwin-arm64.tar.gz",
+          "os": "darwin",
+          "arch": "arm64",
+          "version": "go1.16beta1",
+          "sha256": "fd57f47987bb330fd9b438e7b4c8941b63c3807366602d99c1d99e0122ec62f1",
+          "size": 127918903,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16beta1.darwin-arm64.pkg",
+          "os": "darwin",
+          "arch": "arm64",
+          "version": "go1.16beta1",
+          "sha256": "48d175115f4f3150c93cf6a75f9a7a2c39193d80e4dd951ef4dc111d0acf7f00",
+          "size": 128305727,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.16beta1.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.16beta1",
+          "sha256": "0331c620bb09a3c7f5022bf45f14c28ceb4b043e01ecadde68a1ceff4df50f24",
+          "size": 105189544,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16beta1.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.16beta1",
+          "sha256": "87e72b34ae706c2269e3e665906514d11aa75856da1c99c512206e7cb3a18b74",
+          "size": 131158804,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16beta1.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.16beta1",
+          "sha256": "d32ca50affc0de30a39b63b19a19668ce539390f3d0fa71e966b726cc28ff92e",
+          "size": 105353676,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16beta1.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.16beta1",
+          "sha256": "3931a0d493d411d6c697df6f15d5292fdd8031fde7014fded399effdad4c12d8",
+          "size": 131210078,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16beta1.linux-arm64.tar.gz",
+          "os": "linux",
+          "arch": "arm64",
+          "version": "go1.16beta1",
+          "sha256": "b0f66bca136b4de8fd29645b50efa9941dc5b9eb5a67a3da837d5f8096b3431c",
+          "size": 101904588,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16beta1.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.16beta1",
+          "sha256": "2f31ed765b328f79d58f78a433f6e59295b77da63153fc7582f8d8402c344999",
+          "size": 102566412,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16beta1.linux-ppc64le.tar.gz",
+          "os": "linux",
+          "arch": "ppc64le",
+          "version": "go1.16beta1",
+          "sha256": "a099e01f5a55141e5df190bd531ce090b5a00c7c6a49799b483bcbe6aa0e0eab",
+          "size": 100374723,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16beta1.linux-s390x.tar.gz",
+          "os": "linux",
+          "arch": "s390x",
+          "version": "go1.16beta1",
+          "sha256": "eeda0f0de3fa5daa8e4aa5dc86222f4b6d4b28878e943fb75cdb3d8426844f3c",
+          "size": 105474362,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16beta1.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.16beta1",
+          "sha256": "c67bf5c1524925c109428c28fb51147c1c7b165d9d25aef64e4677afff36c34f",
+          "size": 120514404,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16beta1.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.16beta1",
+          "sha256": "323bdf4925b394a7a4a9cd8769afee5b10db26edd6ee96797c1911c393a8c7df",
+          "size": 105107456,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.16beta1.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.16beta1",
+          "sha256": "f06e2d7f300843473527e8fdd2d496aef5ffa6507ade0ac1141934e5c6ca7d63",
+          "size": 146528007,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.16beta1.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.16beta1",
+          "sha256": "d0d15ac689822c572ebcde1eb945231e0e502add63389f494c208782db68f8d5",
+          "size": 126664704,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.15rc2",
+        "stable": false,
+        "files": [
+         {
+          "filename": "go1.15rc2.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.15rc2",
+          "sha256": "3c6b4db00ec6d8958bb5693729343d08c245b634267130a966f052758579626b",
+          "size": 22999871,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.15rc2.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.15rc2",
+          "sha256": "b07775d30e023c1570b1ba74892fc792834436c790fbb0dbb19ebaae9c155105",
+          "size": 122460978,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15rc2.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.15rc2",
+          "sha256": "c3b33843b6318c80a3d6e4007986aeeea7950f469a7bd6eed549b0633ba9e456",
+          "size": 122814207,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.15rc2.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.15rc2",
+          "sha256": "7d0fafd526c161242265103d674e4b77ec5dae95fe3a8853e45454633bed5022",
+          "size": 100367830,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15rc2.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.15rc2",
+          "sha256": "1f021399526442de11034a8db1bb9ede793078217d3d104775cfe65940122f0e",
+          "size": 121036740,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15rc2.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.15rc2",
+          "sha256": "9c1f1ed42bd5f776f3585e39e3ba165a9b8ac8fde45dafbb6e41e04bae44bb3d",
+          "size": 100599230,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15rc2.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.15rc2",
+          "sha256": "f41a08f630f018bc5d9fd100bd9899516e4965356c78165157eb0eda9a17ac09",
+          "size": 121141036,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15rc2.linux-arm64.tar.gz",
+          "os": "linux",
+          "arch": "arm64",
+          "version": "go1.15rc2",
+          "sha256": "e3e2cd95df2491d3cd74af9f73235dbf031dd2ecaf1140ab2793756be87d915f",
+          "size": 97724631,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15rc2.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.15rc2",
+          "sha256": "60d4d7723ef55d49bbf8326f37011f967048ae9167ef462ee4b9af311c4f3244",
+          "size": 97967384,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15rc2.linux-ppc64le.tar.gz",
+          "os": "linux",
+          "arch": "ppc64le",
+          "version": "go1.15rc2",
+          "sha256": "9eb1d694eaf5104bf80187b6a3c3f0201c598b095f23e8af2bbb19ca3fb12d21",
+          "size": 96404682,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15rc2.linux-s390x.tar.gz",
+          "os": "linux",
+          "arch": "s390x",
+          "version": "go1.15rc2",
+          "sha256": "272793157e27c5a09e216f61f6a84d70808a901b89cc69b9e8cd6f8e019be27a",
+          "size": 101172545,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15rc2.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.15rc2",
+          "sha256": "114cdaf6f17520047e3734017890bfd87bcf7bcf73524a396204a6cc42662a75",
+          "size": 118321265,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15rc2.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.15rc2",
+          "sha256": "fff2536224aad9b2fbb6c9e08bec73414486b8f03ac0f6ff802ac636ab987ccd",
+          "size": 103436288,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.15rc2.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.15rc2",
+          "sha256": "50b6be4a0713cf121af47f17b45c442e7d82b945011d762724cbf11a96fe4f7c",
+          "size": 139114035,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15rc2.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.15rc2",
+          "sha256": "671a4adf3be21a3bced9e9187db06be0bed2c6e317bd0b1444ab31709359fa18",
+          "size": 121085952,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.15rc1",
+        "stable": false,
+        "files": [
+         {
+          "filename": "go1.15rc1.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.15rc1",
+          "sha256": "a19c4d5053a01c1b71827ab6d86f43f2a5266309aa622e04446756304f179c1a",
+          "size": 22994716,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.15rc1.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.15rc1",
+          "sha256": "0572e053ed5fd6e8d6ed24f62832b747d46787288e146e8ba99b574b6e0d67b0",
+          "size": 122416105,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15rc1.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.15rc1",
+          "sha256": "c84bc0a1974e2a77e2e269175f120ee6c8fec6d7e827d650b91cbe4d3fba29de",
+          "size": 122763594,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.15rc1.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.15rc1",
+          "sha256": "479c98371fd29426378596fbc94f96bdc4ac4a9d2bcb4f1ddbc4c1d4edb09ab5",
+          "size": 100312820,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15rc1.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.15rc1",
+          "sha256": "9b14badd4b8dc881c9a15c2493565107ec92e78a71a51c7251cc0c377f92c3f9",
+          "size": 120970013,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15rc1.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.15rc1",
+          "sha256": "e8b09a03cf057fe68806c0d2954ab8d9ca3002558d8ce60a196b836dacb91f4b",
+          "size": 100561702,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15rc1.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.15rc1",
+          "sha256": "ac092ebb92f88366786063e68a9531d5eccac51371f9becb128f064721731b2e",
+          "size": 121089833,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15rc1.linux-arm64.tar.gz",
+          "os": "linux",
+          "arch": "arm64",
+          "version": "go1.15rc1",
+          "sha256": "3baf4336d1bcf1c6707c6e2a402a31cbc87cbd9a63687c97c5149911fe0e5beb",
+          "size": 97686247,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15rc1.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.15rc1",
+          "sha256": "d42df2b62fc7569931fb458952b518e1ee102294efcc4e28c54cce76a7f4cd8f",
+          "size": 97938545,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15rc1.linux-ppc64le.tar.gz",
+          "os": "linux",
+          "arch": "ppc64le",
+          "version": "go1.15rc1",
+          "sha256": "a8599883755d188d24a5012f72f99b3237c2f5223bc1f937b6f055456c1468e3",
+          "size": 96353791,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15rc1.linux-s390x.tar.gz",
+          "os": "linux",
+          "arch": "s390x",
+          "version": "go1.15rc1",
+          "sha256": "0a16994b1f988db12aa44aa9965ae4d07d067489c321e5f7445eb2be63fe2466",
+          "size": 101133985,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15rc1.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.15rc1",
+          "sha256": "2e5f90da04f2ba073501eeb7931b897c9d57c9f8e079ee77620c6b1e4f9a8bdf",
+          "size": 118284699,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15rc1.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.15rc1",
+          "sha256": "53054cda30cddd179d318d4ea2fbdc7ba917ee6411a28ec19cef8862c98d9799",
+          "size": 103391232,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.15rc1.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.15rc1",
+          "sha256": "cc05edc8620ed280dc4540b28312fdd99019a2a14693b6cc9158a26b43e67df3",
+          "size": 139060944,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15rc1.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.15rc1",
+          "sha256": "1f110187ce5716f33a332f16b9c0bb9601d50aa0986f74bde7f15995e25548a8",
+          "size": 121044992,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.15beta1",
+        "stable": false,
+        "files": [
+         {
+          "filename": "go1.15beta1.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.15beta1",
+          "sha256": "78cda84d4217ae0fdb8f87848474be28644bdc1aa16579055f852999a4793ac0",
+          "size": 22940913,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.15beta1.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.15beta1",
+          "sha256": "4ee49feb46169ef942097513b5e783ff0f3f276b1eacfc51083e6e453117bd7e",
+          "size": 125757624,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15beta1.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.15beta1",
+          "sha256": "cd9b1e60c62080ea4c8e3066dad016e994354e97dab407c04e8e4c41e473e568",
+          "size": 126101765,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.15beta1.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.15beta1",
+          "sha256": "77bc3aae4abaa73b537435b6a497043929cf95d7dd17c289f6e1b55180285c94",
+          "size": 103609136,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15beta1.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.15beta1",
+          "sha256": "e13dd8a3e5a04bc1a54b2b70f540fd5e4d77663948c14636e27cf8a8ecfccd7b",
+          "size": 124321008,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15beta1.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.15beta1",
+          "sha256": "83d732a3961006e058f44c9672fde93dbea3d1c3d69e8807d135eeaf21fb80c8",
+          "size": 103857617,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15beta1.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.15beta1",
+          "sha256": "11814b7475680a09720f3de32c66bca135289c8d528b2e1132b0ce56b3d9d6d7",
+          "size": 124430929,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15beta1.linux-arm64.tar.gz",
+          "os": "linux",
+          "arch": "arm64",
+          "version": "go1.15beta1",
+          "sha256": "2648b7d08fe74d0486ec82b3b539d15f3dd63bb34d79e7e57bebc3e5d06b5a38",
+          "size": 100831777,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15beta1.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.15beta1",
+          "sha256": "d4da5c06097be8d14aeeb45bf8440a05c82e93e6de26063a147a31ed1d901ebc",
+          "size": 101114715,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15beta1.linux-ppc64le.tar.gz",
+          "os": "linux",
+          "arch": "ppc64le",
+          "version": "go1.15beta1",
+          "sha256": "33f7bed5ee9d4a0343dc90a5aa4ec7a1db755d0749b624618c15178fd8df4420",
+          "size": 99465720,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15beta1.linux-s390x.tar.gz",
+          "os": "linux",
+          "arch": "s390x",
+          "version": "go1.15beta1",
+          "sha256": "493b4449e68d0deba559e3f23f611310467e4c70d30b3605ff06852f14477457",
+          "size": 104461842,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15beta1.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.15beta1",
+          "sha256": "6ef5301bf03a298a023449835a941d53bf0830021d86aa52a5f892def6356b19",
+          "size": 118261301,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15beta1.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.15beta1",
+          "sha256": "9c034fcb11e5dd53e1666b5e10d8018819998feb94ce51b2c7d9dd45f8a8f9cb",
+          "size": 103399424,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.15beta1.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.15beta1",
+          "sha256": "072c7d6a059f76503a2533a20755dddbda58b5053c160cb900271bb039537f88",
+          "size": 139028358,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.15beta1.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.15beta1",
+          "sha256": "f24171255fa1ebf5383a4d4e6c22fc1d5bf9a3853db8b1e74e6a0ce79e0f1c2a",
+          "size": 120987648,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.14rc1",
+        "stable": false,
+        "files": [
+         {
+          "filename": "go1.14rc1.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.14rc1",
+          "sha256": "76188ea84e95baa502d058c9598020c7654d6adaf40b82cabcf57c68df19963a",
+          "size": 22382787,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.14rc1.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.14rc1",
+          "sha256": "a763dbaaabe6929552891121106286e6e18bc91edf67c031bdefe190e92b6049",
+          "size": 124930044,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.14rc1.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.14rc1",
+          "sha256": "52c5684f7531e31d411bbd8e8fdd2dde9cf1d0be9a4003355ed335f35faa1c5f",
+          "size": 125298164,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.14rc1.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.14rc1",
+          "sha256": "5c094357682c59155adf1b333b29d58db5f98735490cdf43d7e1c0047163047f",
+          "size": 104539482,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.14rc1.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.14rc1",
+          "sha256": "7ebe8d9d050adbeede668ba614a2c0db846fed4d426138615533839bc03c15fe",
+          "size": 123513831,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.14rc1.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.14rc1",
+          "sha256": "831087aa0eba8b6dfa221036d00641613996ac66d7c635f1e34c53d5f0922623",
+          "size": 104737285,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.14rc1.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.14rc1",
+          "sha256": "69398d41e5f6b87cdf3969aae665be4dfd3cc2ef36a61ab47a261f96130ed788",
+          "size": 123546384,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.14rc1.linux-arm64.tar.gz",
+          "os": "linux",
+          "arch": "arm64",
+          "version": "go1.14rc1",
+          "sha256": "a5509448b06f02f5198fe8bbf5af88ab483af9c46f231c3f308748016fbc32c9",
+          "size": 100919922,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.14rc1.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.14rc1",
+          "sha256": "bfe041f7d2a62f895f2d11703a29bdd31a48cca9a3c36418d59680bc1cbb8a6d",
+          "size": 101664867,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.14rc1.linux-ppc64le.tar.gz",
+          "os": "linux",
+          "arch": "ppc64le",
+          "version": "go1.14rc1",
+          "sha256": "fe1bf34d2b117d785f2fb33151c44ca8bc2188678c9e903fa0ad30573547b412",
+          "size": 99754100,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.14rc1.linux-s390x.tar.gz",
+          "os": "linux",
+          "arch": "s390x",
+          "version": "go1.14rc1",
+          "sha256": "2302fa0e30144a969cb1879eed8aeb9a82c2b520fcda8aebbb20a539ad427c25",
+          "size": 105178463,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.14rc1.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.14rc1",
+          "sha256": "bf40f37312379ea350d32acd3b46bcb6a00d1601ae4824681f4eb665a0331280",
+          "size": 117880058,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.14rc1.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.14rc1",
+          "sha256": "3c32dbe017eb5a2773eeef002ea35166c7d0df5127f6bb9ec1e571699ea9d99c",
+          "size": 103464960,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.14rc1.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.14rc1",
+          "sha256": "4f714ebb1904b96e1a5fe551ba195d9bcef7a41706d5b34e377d0106020b3f04",
+          "size": 137607416,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.14rc1.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.14rc1",
+          "sha256": "c8cb4ff61d49f25cd87794ce9f97cb6d32a6ff5fc734929a46ac9ca70b7b297a",
+          "size": 120569856,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.14beta1",
+        "stable": false,
+        "files": [
+         {
+          "filename": "go1.14beta1.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.14beta1",
+          "sha256": "af952217fcb408180006f29e77f1c3b871192fba7f99abd5aa421cf2f0358fea",
+          "size": 22331591,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.14beta1.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.14beta1",
+          "sha256": "55a9028c629f88c8f81f5d37bfb3c52f7568c77dceaca48cb054f0d29682cbbb",
+          "size": 124643932,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.14beta1.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.14beta1",
+          "sha256": "660fdbdd758cba1c29f427edf61fac17f90516a87ac33f336500143f2fab3a7d",
+          "size": 125003164,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.14beta1.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.14beta1",
+          "sha256": "4bee47f7c4cb3e0459cc4ef0626ff342fb15bf192cb458477774e3735aea8ad8",
+          "size": 104249192,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.14beta1.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.14beta1",
+          "sha256": "bec4bf142f9f0b38caaef76912b53081ca96374e807ffe56669b22433b89b885",
+          "size": 123246624,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.14beta1.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.14beta1",
+          "sha256": "bcbfb2ea92cfef54c587427435ae5cbe50473d9158beef97aa5d5edd43d1a9d8",
+          "size": 104448986,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.14beta1.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.14beta1",
+          "sha256": "ebe68aa4219b673dbd060b8a6d9a339b6b6b0383772aa4349c8183f0a8f339e4",
+          "size": 123255488,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.14beta1.linux-arm64.tar.gz",
+          "os": "linux",
+          "arch": "arm64",
+          "version": "go1.14beta1",
+          "sha256": "91a92cfb7644c59c4b51d50fb7225b898675effaa65659a71c06aa6a42c0ada5",
+          "size": 100632637,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.14beta1.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.14beta1",
+          "sha256": "f0542513b997ef6b5f6ff4b9a2b9502fe6743746f2639ffd48dd53d7cb958f6d",
+          "size": 101358295,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.14beta1.linux-ppc64le.tar.gz",
+          "os": "linux",
+          "arch": "ppc64le",
+          "version": "go1.14beta1",
+          "sha256": "69f8d16e13912cd3caa2fe70addae9929d518d6c875cfd581bd914e0ce2d6d80",
+          "size": 99472660,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.14beta1.linux-s390x.tar.gz",
+          "os": "linux",
+          "arch": "s390x",
+          "version": "go1.14beta1",
+          "sha256": "3252c14611af17e435a5160467c581acc31b4a4ce4e8e17688befabba3ba710f",
+          "size": 104922670,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.14beta1.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.14beta1",
+          "sha256": "dc3c15c67331b7fd584fbf538ae2c742bbf9fc2337097fde2090076037fd300c",
+          "size": 117579895,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.14beta1.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.14beta1",
+          "sha256": "0a2d2dcdd90abbeced8eb880138d7376d52c38eb21ed0927238cc0f2add2ee55",
+          "size": 103223296,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.14beta1.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.14beta1",
+          "sha256": "daa07bea59ae0a11f8b5898f6f6f5b781ded4ee3c627400c857fc91ce5af5045",
+          "size": 137297342,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.14beta1.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.14beta1",
+          "sha256": "2c677fa019f1df66bc350b2b72565830cfbda1f2a16b1e832ca2643d6a85973c",
+          "size": 120307712,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.13rc2",
+        "stable": false,
+        "files": [
+         {
+          "filename": "go1.13rc2.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.13rc2",
+          "sha256": "0c7387b3be32718282a39faa3020ff30365ef70e64fa71e10017a986587b7fe9",
+          "size": 21621673,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.13rc2.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.13rc2",
+          "sha256": "d8b966c35784777c3d720ef4dc4626956ccf7c4f6540b09eb9d08a86df207891",
+          "size": 121214100,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.13rc2.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.13rc2",
+          "sha256": "17cc3162a059e6cf3bcd27c168997b0dae1eb4f2e92cacdaa27d1d68c42cd653",
+          "size": 120117020,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.13rc2.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.13rc2",
+          "sha256": "e58e08f71bcd24de30804f4c8ebc8ef5e30f656e2f1e9a51307404d424889e50",
+          "size": 101164144,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.13rc2.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.13rc2",
+          "sha256": "eb10526c59e3357fdb5e38a23c93c81d686b46538c4600fe1e65596ba2604b37",
+          "size": 120012408,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.13rc2.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.13rc2",
+          "sha256": "5f5d235b73672ee5d26917d3907f8f1966af60d4391477a5afd4300d070ca852",
+          "size": 101286521,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.13rc2.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.13rc2",
+          "sha256": "3cd4490021a5f1f25a7440edca03910e40a38e587b578cf52ab7143a81db1861",
+          "size": 120044882,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.13rc2.linux-arm64.tar.gz",
+          "os": "linux",
+          "arch": "arm64",
+          "version": "go1.13rc2",
+          "sha256": "184c9fff6bba9da1cf23ba7f52561cc777ac7feaf73621b3824f4a30ffa4648d",
+          "size": 97596071,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.13rc2.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.13rc2",
+          "sha256": "deebe2b723c818293046629344f09ead1610fba608aea038bcf25da70766f944",
+          "size": 98268134,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.13rc2.linux-ppc64le.tar.gz",
+          "os": "linux",
+          "arch": "ppc64le",
+          "version": "go1.13rc2",
+          "sha256": "7656da8bb13e450754d5df35c7d21dafb5847b00779dcc08f3c41eec7d817037",
+          "size": 96428212,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.13rc2.linux-s390x.tar.gz",
+          "os": "linux",
+          "arch": "s390x",
+          "version": "go1.13rc2",
+          "sha256": "6016103bab62f1fe6b8f90665888a23ae8c825a8e7db7a607877298148e593cf",
+          "size": 102140008,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.13rc2.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.13rc2",
+          "sha256": "0631cdae345f47e4b03036a4f53216feefdf443e36404bc68b3a5af1a2cbba8a",
+          "size": 114186901,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.13rc2.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.13rc2",
+          "sha256": "fc5d13e8271fdf6cc4171bd05510838f3c7a593421ba98e66ddf81d8f231c05f",
+          "size": 100114432,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.13rc2.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.13rc2",
+          "sha256": "ed34ad4b9594ab0d19b2fed9b07ea56c573279f46041b3c40a17c39a35bf285c",
+          "size": 133888664,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.13rc2.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.13rc2",
+          "sha256": "a73d1ea3f4d49f445e14139d27113d51c504e3d141efdc0f7b5eff570b3e2ef1",
+          "size": 117125120,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.13rc1",
+        "stable": false,
+        "files": [
+         {
+          "filename": "go1.13rc1.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.13rc1",
+          "sha256": "dc5c1f4501daf486f69ca9a795202b289824c303291bf26c42a5b6c1770ba3a9",
+          "size": 21621119,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.13rc1.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.13rc1",
+          "sha256": "b895cf067934f09f4eacfcb66aca84b6235dbb497906473111332532c3b8ec2f",
+          "size": 121206296,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.13rc1.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.13rc1",
+          "sha256": "2463f102628151d1db266050bee0315145d79d69eac8d2b6ebd4b1d14d652455",
+          "size": 120084252,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.13rc1.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.13rc1",
+          "sha256": "3cf6f9887f9154c97084a10b08a1c86eaa5f7660e734c3c65c691a3805ae67ba",
+          "size": 101144456,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.13rc1.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.13rc1",
+          "sha256": "9e4f3932fc1787ebd4296f02799db00e266b73668db483b73d23831110da1def",
+          "size": 120012312,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.13rc1.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.13rc1",
+          "sha256": "98368195013a6140573835db93038a7977c61cabff53618a785659edb9378bb1",
+          "size": 101260324,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.13rc1.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.13rc1",
+          "sha256": "0b45d086aefcfb9d0ebe7fc9ffbe470e45f9c104a6a97ea275512152cdbfead1",
+          "size": 120033684,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.13rc1.linux-arm64.tar.gz",
+          "os": "linux",
+          "arch": "arm64",
+          "version": "go1.13rc1",
+          "sha256": "be16145c9fa218340766b19edd175b109adab826155add2fd504430a751aaa19",
+          "size": 97566865,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.13rc1.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.13rc1",
+          "sha256": "d0118038c68276179523dfffba3ad49662842b8e4e37b5801d753c731241d745",
+          "size": 98251780,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.13rc1.linux-ppc64le.tar.gz",
+          "os": "linux",
+          "arch": "ppc64le",
+          "version": "go1.13rc1",
+          "sha256": "e351c396262b3c411459e08a2ff9bec9d720760bd8811fd1f59262d02f9f504f",
+          "size": 96405346,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.13rc1.linux-s390x.tar.gz",
+          "os": "linux",
+          "arch": "s390x",
+          "version": "go1.13rc1",
+          "sha256": "2fd64292498fb70074ff4560da4a7e444d3325c219a6987f4b2186d231244921",
+          "size": 102139650,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.13rc1.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.13rc1",
+          "sha256": "7a39d6e3c8b1996f22a9aae69e81c17ef8901ffdee396ceffff6da23361fa117",
+          "size": 114171393,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.13rc1.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.13rc1",
+          "sha256": "42d2e04e3d6545b534e3d93d75db38583a48174cfc07568ee84daf84efc8d06e",
+          "size": 100106240,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.13rc1.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.13rc1",
+          "sha256": "54ff506157d767135e775188e4ecdb44d34ba215463ec69674f4ac38cb20f10b",
+          "size": 133868042,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.13rc1.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.13rc1",
+          "sha256": "92a44b10ff42ce6114118c6be24559f8179a524519f6c36aff9f5a5855d046ce",
+          "size": 117104640,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.13beta1",
+        "stable": false,
+        "files": [
+         {
+          "filename": "go1.13beta1.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.13beta1",
+          "sha256": "e8a7c504cd6775b8a6af101158b8871455918c9a61162f0180f7a9f118dc4102",
+          "size": 21607365,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.13beta1.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.13beta1",
+          "sha256": "7af1aead60905c14085300b38a39b8ea2da5d6bf55084caa759a8bdf41ae0c32",
+          "size": 123009145,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.13beta1.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.13beta1",
+          "sha256": "f7f0a0dd1fb18337e182fc0d93ecc71622b36fb3dfa2644a4f8bc0f67aa5f84d",
+          "size": 121841440,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.13beta1.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.13beta1",
+          "sha256": "b9505fa721ab1e8c972172374fa2db52e67955798c5c8574620f74bd7900a808",
+          "size": 101149848,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.13beta1.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.13beta1",
+          "sha256": "9c1fb2edaf403bba04d49f2f7da4d09b14c63bbe6143f1ff1e8ba56b4e17d013",
+          "size": 120028856,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.13beta1.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.13beta1",
+          "sha256": "38039e4f7b6eea8f55e91d90607150d5d397f9063c06445c45009dd1e6dba8cc",
+          "size": 101264030,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.13beta1.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.13beta1",
+          "sha256": "dbd131c92f381a5bc5ca1f0cfd942cb8be7d537007b6f412b5be41ff38a7d0d9",
+          "size": 120025241,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.13beta1.linux-arm64.tar.gz",
+          "os": "linux",
+          "arch": "arm64",
+          "version": "go1.13beta1",
+          "sha256": "298a325d8eeba561a26312a9cdc821a96873c10fca7f48a7f98bbd8848bd8bd4",
+          "size": 107719954,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.13beta1.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.13beta1",
+          "sha256": "77993f1dce5b4d080cbd06a4553e5e1c6caa7ad6817ea3c62254b89d6f079504",
+          "size": 98239746,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.13beta1.linux-ppc64le.tar.gz",
+          "os": "linux",
+          "arch": "ppc64le",
+          "version": "go1.13beta1",
+          "sha256": "0f3c5c7b7956911ed8d1fc4e9dbeb2584d0be695c5c15b528422e3bb2d5989f0",
+          "size": 96355036,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.13beta1.linux-s390x.tar.gz",
+          "os": "linux",
+          "arch": "s390x",
+          "version": "go1.13beta1",
+          "sha256": "877065ac7d1729e5de1bbfe1e712788bf9dee5613a5502cf0ba76e65c2521b26",
+          "size": 102098553,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.13beta1.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.13beta1",
+          "sha256": "f0908f1703c642950442317f7581c8254842f00298e4e0f511d1513c87e3c64d",
+          "size": 115905309,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.13beta1.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.13beta1",
+          "sha256": "6189e5d13ef054117fc45fe028a4b3c6b22fc8301a422e6fb13f332a864a8da9",
+          "size": 100290560,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.13beta1.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.13beta1",
+          "sha256": "08098b4b0e1a105971d2fced2842e806f8ffa08973ae8781fd22dd90f76404fb",
+          "size": 135659701,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.13beta1.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.13beta1",
+          "sha256": "989098d4f3535ebd0126f381eb9ff097373c060ad8fce902730696866e84f297",
+          "size": 117346304,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.12rc1",
+        "stable": false,
+        "files": [
+         {
+          "filename": "go1.12rc1.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.12rc1",
+          "sha256": "ed1d4f8e8a33f0d4a59a2f642584c7c6375fce2f8a4edaece73309cf2c89b8ee",
+          "size": 21960368,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.12rc1.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.12rc1",
+          "sha256": "a5d5f0a5bec8edde1c80dba0fe84eaf3eb7b515d6ae52982150c583ce498aa97",
+          "size": 128399284,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.12rc1.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.12rc1",
+          "sha256": "b195d42c22a8518da4521bf25512fd9fd7a76ebe17afdd933bcc4e44ee4668db",
+          "size": 127588006,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.12rc1.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.12rc1",
+          "sha256": "c3a2a496aaac1c38477068d2570a7aa8a5dfdf1bd18e855378030422fe22b740",
+          "size": 108557884,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.12rc1.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.12rc1",
+          "sha256": "3b3d9319b3c7fa3a2442ec2371934c89cf3dd9a640c24eec9562801815853b87",
+          "size": 127285414,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.12rc1.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.12rc1",
+          "sha256": "1d8615576655decbadeefcfaa6d5144b370dbea67fd4b426f58b573deedbd918",
+          "size": 108669323,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.12rc1.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.12rc1",
+          "sha256": "e5a03e1f2e065b17b2fbbd3429f18a6f51fe2848e0120586652b9f14ada72c9a",
+          "size": 127214219,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.12rc1.linux-arm64.tar.gz",
+          "os": "linux",
+          "arch": "arm64",
+          "version": "go1.12rc1",
+          "sha256": "654b90f75902d501e2201a7b438965132fd1242a102f54529e9ff7dbbdf0d4bb",
+          "size": 113387627,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.12rc1.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.12rc1",
+          "sha256": "62126e4ca72e2fea9856fe0ec1a0f28cf1b385fb362d32cb56413c39cab318f8",
+          "size": 105595109,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.12rc1.linux-ppc64le.tar.gz",
+          "os": "linux",
+          "arch": "ppc64le",
+          "version": "go1.12rc1",
+          "sha256": "cb6c7ba83ee8211da1d13d6db148adfdd6b86a790d3974d0c5702d229ca1da40",
+          "size": 103540241,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.12rc1.linux-s390x.tar.gz",
+          "os": "linux",
+          "arch": "s390x",
+          "version": "go1.12rc1",
+          "sha256": "40208d21fca8469c20054e67250f288ab62d68794690aa2c0324d67018ba99c2",
+          "size": 110297983,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.12rc1.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.12rc1",
+          "sha256": "d2e3ffd1328bcdd22715c32557e022d231c3c9a2aaf8d7cd9219cd3813b7188f",
+          "size": 122535395,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.12rc1.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.12rc1",
+          "sha256": "5f3bc965bcf2d8aca0ff973656fb7b5466219b0a6c048afa9bc8277431b6a68e",
+          "size": 105926656,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.12rc1.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.12rc1",
+          "sha256": "cf3e163c6106f4f272816fa53d1e01e0cabff8dd797732f46513bbc5ea4f1843",
+          "size": 142115097,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.12rc1.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.12rc1",
+          "sha256": "75e854192affaf248f520d9d2b6014d1500fd393512dacdebfc6cb67e08af0c0",
+          "size": 122867712,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.12beta2",
+        "stable": false,
+        "files": [
+         {
+          "filename": "go1.12beta2.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.12beta2",
+          "sha256": "fd3f4e1860ac59d647c22a2c1589fcf4a96c02bbbfef1ca1ea44bc25cf62a490",
+          "size": 21929952,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.12beta2.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.12beta2",
+          "sha256": "502c0933bbd54f94ac438fc96a367b8aa14e4b77e6656b66ddfa2bf7da3a31cf",
+          "size": 130220097,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.12beta2.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.12beta2",
+          "sha256": "f61904765b2c13aa2aa728720ce1bbc1afcce4a4265b4172d9537ea000e4ccb9",
+          "size": 129361572,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.12beta2.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.12beta2",
+          "sha256": "6439d29a510365f0c36565724135c6b2a9e640e2fa898489d609553e181ceeaa",
+          "size": 108379080,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.12beta2.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.12beta2",
+          "sha256": "ed083d6525c98b666f19f78a24a0cfc4410162f28b54da0f3904c3a4b199ebe7",
+          "size": 131143960,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.12beta2.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.12beta2",
+          "sha256": "ffe0d1c92473b2fd653e399c1ddb11535b9666f22b6ae5653bd1fb4f84534c46",
+          "size": 114821821,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.12beta2.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.12beta2",
+          "sha256": "9e4884b46a72e0558187a8af6e8733e039432df1b755f14b361f18b63fa5a63e",
+          "size": 133223771,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.12beta2.linux-arm64.tar.gz",
+          "os": "linux",
+          "arch": "arm64",
+          "version": "go1.12beta2",
+          "sha256": "77d80484e455ad65aa0778aa82391c02ded01a37ee65f7887167dc03a6ef3251",
+          "size": 114693786,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.12beta2.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.12beta2",
+          "sha256": "d41674dda2e33a539929a980c7ba8d68c90c8aabcb138b65a2dc36704af02ace",
+          "size": 105419273,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.12beta2.linux-ppc64le.tar.gz",
+          "os": "linux",
+          "arch": "ppc64le",
+          "version": "go1.12beta2",
+          "sha256": "a1701e3c216c970a833248d6e5df5f2c27c6103e8e3bde34c5c3c25e839e87f9",
+          "size": 103372668,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.12beta2.linux-s390x.tar.gz",
+          "os": "linux",
+          "arch": "s390x",
+          "version": "go1.12beta2",
+          "sha256": "bb4ea794a8fa459ad596c03b08fba9de647c62369c74f5daf21a6bae8c855b11",
+          "size": 110086948,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.12beta2.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.12beta2",
+          "sha256": "44b4003b831651719723b9d8b11313c1f20412ab38fa0354931e78f9d18dd9f3",
+          "size": 122311630,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.12beta2.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.12beta2",
+          "sha256": "23dcde0fdd0427ed5684509e6c9f8e997fc0f70a0f0d39c37dce50f3c3c2169b",
+          "size": 105750528,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.12beta2.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.12beta2",
+          "sha256": "6d1878249d99dc9ba3e7c7da05470cf7c4fa70b319eeb8e6248dd5a26ff3d870",
+          "size": 141875166,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.12beta2.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.12beta2",
+          "sha256": "22a70528f3624170eae826c79ca021248cdcda7b698f9f4e67967318f16c6602",
+          "size": 122650624,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.12beta1",
+        "stable": false,
+        "files": [
+         {
+          "filename": "go1.12beta1.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.12beta1",
+          "sha256": "639585de6bfb67865a85cd750d41ecc39968039dafb9d1fdb15361eb118d150a",
+          "size": 21820133,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.12beta1.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.12beta1",
+          "sha256": "e49bf83ae10b2232d2efa918f0e9df1d76f93a0c6b0ea18c11edd9ef9defa505",
+          "size": 124596161,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.12beta1.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.12beta1",
+          "sha256": "2e656d64737ecbec17f41b602ca3d0df052e3dbbc8cb74f9ff4c6229edc3c2c5",
+          "size": 123815590,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.12beta1.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.12beta1",
+          "sha256": "20ce27a36c5724c20f4dacac324fca9bc7835bb4c1b0187cf0e85d365a7294c2",
+          "size": 106586066,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.12beta1.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.12beta1",
+          "sha256": "063220caeeca37dfc6575094c4a9ffa443dd0aea1754a5154b7b4271234aac45",
+          "size": 125021539,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.12beta1.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.12beta1",
+          "sha256": "5c93266b9b9f6e4ac452517b073a54d2dbb4cbbae901bc7e2b5d34415adf658b",
+          "size": 106660357,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.12beta1.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.12beta1",
+          "sha256": "65bfd4a99925f1f85d712f4c1109977aa24ee4c6e198162bf8e819fdde19e875",
+          "size": 124979327,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.12beta1.linux-arm64.tar.gz",
+          "os": "linux",
+          "arch": "arm64",
+          "version": "go1.12beta1",
+          "sha256": "df79a288b2c569bd26e43ea3acc245b7eabae897b4783f7b4acffdd97ba0a01c",
+          "size": 101863978,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.12beta1.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.12beta1",
+          "sha256": "e0ba7091227b42e98a9ed83f52e3821f7b3b836a16a5815ccf237bcaa590083a",
+          "size": 103714582,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.12beta1.linux-ppc64le.tar.gz",
+          "os": "linux",
+          "arch": "ppc64le",
+          "version": "go1.12beta1",
+          "sha256": "8ae18d580913cc4cb67cdac36c058aad279419640f469931e44d6b7f0bbd9062",
+          "size": 101622867,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.12beta1.linux-s390x.tar.gz",
+          "os": "linux",
+          "arch": "s390x",
+          "version": "go1.12beta1",
+          "sha256": "c575e5835a0ed3b19040497e24f7de6913eb73a42983e828f5dc2af4c9fcecf7",
+          "size": 108328294,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.12beta1.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.12beta1",
+          "sha256": "2cd954a478fd8820a4efe4ec69c7d0e8bc6bef0f835e74edf72b3c5fd0a69ba8",
+          "size": 118797274,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.12beta1.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.12beta1",
+          "sha256": "d729ca1429a764bd071d68320a097771aac83bc4c337de615c3594baa92a5ea1",
+          "size": 103956480,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.12beta1.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.12beta1",
+          "sha256": "167824d31e5a75a89e0ee159561042e144498f8f2cc725767277ccbcf749684b",
+          "size": 138068137,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.12beta1.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.12beta1",
+          "sha256": "3df555f2d32118018ef5d24afe1070b7cd4e8368396a1c4284954cd8dfa0128a",
+          "size": 120659968,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.11rc2",
+        "stable": false,
+        "files": [
+         {
+          "filename": "go1.11rc2.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.11rc2",
+          "sha256": "5947695c5289ddb6ddc22d01d498b94ddb86bb6775593d772156c4e72a482516",
+          "size": 21092244,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.11rc2.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.11rc2",
+          "sha256": "7841133bd5660d4aaaf56dc6d684a1e9208d7756a0d4683b569ee006d20312cd",
+          "size": 124132498,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.11rc2.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.11rc2",
+          "sha256": "006b9774aec183471079e7a6efb011d8643bc02c63d9824ea0c4c0998c5a996a",
+          "size": 123348643,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.11rc2.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.11rc2",
+          "sha256": "04731b5a5bcdf04ec793c7e222316b57e1569faa50b1182ae3209371b225ecb2",
+          "size": 104510139,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.11rc2.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.11rc2",
+          "sha256": "52a28d7e585f268ff3756ec23e2b1d57963b6d21349b1358bbb70991a523ca2c",
+          "size": 125096550,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.11rc2.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.11rc2",
+          "sha256": "a1982f3af77875c1e8f7c5056ce815236a62902472aceb95fc66e47555d88010",
+          "size": 110455969,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.11rc2.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.11rc2",
+          "sha256": "7d3fc1dec64b056cbd22ffd80bb9733725c1296aabfd58cc92bab8a5c6560e03",
+          "size": 127163630,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.11rc2.linux-arm64.tar.gz",
+          "os": "linux",
+          "arch": "arm64",
+          "version": "go1.11rc2",
+          "sha256": "5b160c1ea4c863f82d5d9ebad51edc08f5a5ecf368d315c8aff2c99420fb075c",
+          "size": 100911616,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.11rc2.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.11rc2",
+          "sha256": "502272db03f6c6883fec5c9e17730b469966d87f9c07e6a306637ddf0fe83526",
+          "size": 101717351,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.11rc2.linux-ppc64le.tar.gz",
+          "os": "linux",
+          "arch": "ppc64le",
+          "version": "go1.11rc2",
+          "sha256": "d58470aa1e79282b35f7b61cb8d1ac3f0cbecd6d837076795a30003c947feef2",
+          "size": 99467218,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.11rc2.linux-s390x.tar.gz",
+          "os": "linux",
+          "arch": "s390x",
+          "version": "go1.11rc2",
+          "sha256": "85f56c3847eb1ba6b1faf14869671b6d7c31d5ef0082dc1c32a2c53a5e831c76",
+          "size": 100450324,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.11rc2.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.11rc2",
+          "sha256": "30eaf4d02310c858eb8f095a9a4ce61296f6b6b95fcc9d850c53910409f31a26",
+          "size": 117236329,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.11rc2.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.11rc2",
+          "sha256": "d88b8ab303ba1a9d072e4c92f6989899fd19fb3b5dec1ee1d8e58f345cb1c0a6",
+          "size": 101101568,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.11rc2.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.11rc2",
+          "sha256": "edd1ad3f94ef31eacfe267f30df00ac832cc9547e88de03e1368ae23630070eb",
+          "size": 135032717,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.11rc2.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.11rc2",
+          "sha256": "5527d383c3651b2c985b09a88739ba342255472d17a67f0cfae66c6165061197",
+          "size": 116649984,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.11rc1",
+        "stable": false,
+        "files": [
+         {
+          "filename": "go1.11rc1.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.11rc1",
+          "sha256": "fcb8778ad5d1bb7f5bfd1564ba4107894011f1d65f69be9fa1e693f6b5143828",
+          "size": 21080096,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.11rc1.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.11rc1",
+          "sha256": "ff20b76a592041e1e82930abb745176fde936b1fc10ccbfd85ea23195d1bf69f",
+          "size": 174178367,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.11rc1.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.11rc1",
+          "sha256": "853ff554737a512a974feb4d0c6a22e7fb0678ac3389f4c4fd390be2ebab4f6c",
+          "size": 173135530,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.11rc1.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.11rc1",
+          "sha256": "8d3cfc02c4d63d71ea442a3f3431484d9a797e017b433a62975586030fb7b9fb",
+          "size": 154853589,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.11rc1.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.11rc1",
+          "sha256": "bbcef9702fd1106439808b4b1e3f9aeddd84f4d939dd189e3038524c66d7f6b5",
+          "size": 175143457,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.11rc1.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.11rc1",
+          "sha256": "afe8f516fbd0316981e70fc0dda8c67116837baaa0431ee2da47f4fee4614433",
+          "size": 160876648,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.11rc1.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.11rc1",
+          "sha256": "1a071f069982427b245aea736d3174e065a12e8481c34051c672d62a5ca59ca9",
+          "size": 177294517,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.11rc1.linux-arm64.tar.gz",
+          "os": "linux",
+          "arch": "arm64",
+          "version": "go1.11rc1",
+          "sha256": "8a3d96e3e7604cf5390b7e318ff35112cdb13e0e44ddf0130659cefd196ab50e",
+          "size": 150386952,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.11rc1.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.11rc1",
+          "sha256": "6f2c0a53850e7dcd2f1592eb51325fa5da20ee953512bebf1b0d3fb046874dc4",
+          "size": 151756936,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.11rc1.linux-ppc64le.tar.gz",
+          "os": "linux",
+          "arch": "ppc64le",
+          "version": "go1.11rc1",
+          "sha256": "972e7b6bfecee780a9cd970100297b35bed4c82cacc2bd55d78428928b66683d",
+          "size": 149001454,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.11rc1.linux-s390x.tar.gz",
+          "os": "linux",
+          "arch": "s390x",
+          "version": "go1.11rc1",
+          "sha256": "bd30adfb32de8c441fc0b12a9a9acbd5098a77ab77609269aed7ea4f8dd682ae",
+          "size": 150535490,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.11rc1.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.11rc1",
+          "sha256": "b036557b7b8f312787c8b64852bbaaa371ef4307139c42b385c5e8630313c463",
+          "size": 168551778,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.11rc1.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.11rc1",
+          "sha256": "a6f09abba8de8ab5b09c15154a740db2a9592e7420ae098f722321e3b185756a",
+          "size": 149168128,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.11rc1.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.11rc1",
+          "sha256": "bcd482bdae421c580897ce0bb350f56679ebe676817ead572ee3a5942611bcc9",
+          "size": 186126261,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.11rc1.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.11rc1",
+          "sha256": "ef096ca23edf579b05f2536305d611141e7eda4f81fe8db781244da0bfcf6633",
+          "size": 164413440,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.11beta3",
+        "stable": false,
+        "files": [
+         {
+          "filename": "go1.11beta3.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.11beta3",
+          "sha256": "b11a92814601c85910e3f98dd06b941974d03b48c2c255defbee1cc99f19d721",
+          "size": 21066605,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.11beta3.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.11beta3",
+          "sha256": "963efb4ca5840402da3e2332ae0bbd83b0cb88131c0b8c9a64206a9cc594c6af",
+          "size": 174120698,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.11beta3.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.11beta3",
+          "sha256": "1d8fc25e218a4728d55fbee4fecdc2b730ac0e29fe0bf758b694c6dd65a238e6",
+          "size": 173086371,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.11beta3.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.11beta3",
+          "sha256": "240be100030563177d9bc18ac56c0a5861bfcdb7a1266a28bced77df326db4f5",
+          "size": 154778493,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.11beta3.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.11beta3",
+          "sha256": "777c89a74f02ffd3280fd8588ba822f92aa45ec626a1f01c8c408c5ded3fc6e1",
+          "size": 175077199,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.11beta3.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.11beta3",
+          "sha256": "e3e4e1271aa74f7dc64c586048f351e89d7ab20b5f3c3a518e87a628f5abf582",
+          "size": 160819241,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.11beta3.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.11beta3",
+          "sha256": "674c1091f4712c1cfdcd77ecddafe6aef81cbda740af64a6e3f893ddf3dfb11c",
+          "size": 177220425,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.11beta3.linux-arm64.tar.gz",
+          "os": "linux",
+          "arch": "arm64",
+          "version": "go1.11beta3",
+          "sha256": "d8fb9d36a3c862a68db828eb22268e0723e3e245f41cc33f5da0a5b7e293fea5",
+          "size": 150336389,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.11beta3.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.11beta3",
+          "sha256": "491e4d1288ad9f69d16e8ec990d4a4a2b9cc494c3b9488743a96c168424cbb5c",
+          "size": 151699966,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.11beta3.linux-ppc64le.tar.gz",
+          "os": "linux",
+          "arch": "ppc64le",
+          "version": "go1.11beta3",
+          "sha256": "6fe3a4db6a43a59fbe364069fd94536e1d2920df897d5ec93bea7fd519031c54",
+          "size": 148917377,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.11beta3.linux-s390x.tar.gz",
+          "os": "linux",
+          "arch": "s390x",
+          "version": "go1.11beta3",
+          "sha256": "518762a66c9992d667bf7cae4adda285d14f856413ccc7cd853876aae0670382",
+          "size": 150472405,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.11beta3.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.11beta3",
+          "sha256": "78d57b4f048339352be93a0b1ffac3068600bb2e8823c171dc0cadc89c9b2d4e",
+          "size": 168460071,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.11beta3.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.11beta3",
+          "sha256": "35c7007299f1f19efd6f750de663aa0e7793ed6dadc08d1c68ecde69c4d5e110",
+          "size": 149098496,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.11beta3.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.11beta3",
+          "sha256": "ac7d4032fe4f80bd862992829dfbc9f6c4c89c294440a8e1b929dd9a43439011",
+          "size": 186034998,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.11beta3.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.11beta3",
+          "sha256": "d99fc2e79dcc1047b297892dbe9682b1e5648f3566284eaa40d80db79f5c9ee1",
+          "size": 164356096,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.11beta2",
+        "stable": false,
+        "files": [
+         {
+          "filename": "go1.11beta2.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.11beta2",
+          "sha256": "50f4bd23334f54c60ad7d07c742874c62488cf1556fa3e6e51dc03d5f5abda81",
+          "size": 21030971,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.11beta2.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.11beta2",
+          "sha256": "12ef48702dc38ce3545152a7eb060c4ac47796212cc10c67f36c4116f96beae4",
+          "size": 174217731,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.11beta2.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.11beta2",
+          "sha256": "5e34da9201fff706c0c40a221f72cd5e03f61eba5930f86de029c1c8b486abd9",
+          "size": 173176493,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.11beta2.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.11beta2",
+          "sha256": "b8128ba8304959d8b456755a3598cc93d4093183050583ddb60f37cf8dd671fe",
+          "size": 154890372,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.11beta2.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.11beta2",
+          "sha256": "357b430548e27fb57cdfc87b2577b6babf858326c98271e16f306e7ad106e225",
+          "size": 175159801,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.11beta2.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.11beta2",
+          "sha256": "acc26b494699f7dca7e30ec2c08d0f2af8813437a234f17605fafe9c7c8cf69e",
+          "size": 160956462,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.11beta2.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.11beta2",
+          "sha256": "ccb60f1ae6efe4fcef115db8143eb7f9ba134c63486f47b2c5176706ede35af5",
+          "size": 177327748,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.11beta2.linux-arm64.tar.gz",
+          "os": "linux",
+          "arch": "arm64",
+          "version": "go1.11beta2",
+          "sha256": "835fc6ebae5cb4368fc39683a911fe5a25c36b4251b2b254112f3fc8f36a9f39",
+          "size": 150371916,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.11beta2.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.11beta2",
+          "sha256": "3242225cc9bb151789b4ba606903862b68b0e81682a5ab75245d76ab1ddf38fb",
+          "size": 151820014,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.11beta2.linux-ppc64le.tar.gz",
+          "os": "linux",
+          "arch": "ppc64le",
+          "version": "go1.11beta2",
+          "sha256": "31168f17e2791e664e591dc4c5e2c37ab5c3b942a2898d84075437daed3fc9f9",
+          "size": 148996023,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.11beta2.linux-s390x.tar.gz",
+          "os": "linux",
+          "arch": "s390x",
+          "version": "go1.11beta2",
+          "sha256": "648b0f22ff517668bf4b642749a2a479d421f69b1e11bcd0ab1a71994e1c94db",
+          "size": 150548520,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.11beta2.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.11beta2",
+          "sha256": "674b3fcdc6a7a90e2956531e9c3d903c4e0ba07eb28226c5333b6b2c36b34879",
+          "size": 168507164,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.11beta2.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.11beta2",
+          "sha256": "70815c848bff65a0be9387d92e38bfb05acc4758f8e40e97c02782e3e2907410",
+          "size": 149143552,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.11beta2.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.11beta2",
+          "sha256": "91072cdc2cbf7b0e94c5706aea86e09d4a044aa6b60f4db4c0869ca29a8befa4",
+          "size": 186053440,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.11beta2.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.11beta2",
+          "sha256": "695af00dc74432e0e73a3b50399417bcb7ce05a4cf14db7d96b504623a8afaab",
+          "size": 164323328,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.11beta1",
+        "stable": false,
+        "files": [
+         {
+          "filename": "go1.11beta1.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.11beta1",
+          "sha256": "5955eeb8f45e02aa5357fc18e62f1fe6c1b19e0c50aba93b8b9d9ef13b862dda",
+          "size": 20777444,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.11beta1.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.11beta1",
+          "sha256": "d7f2985cd2f6555df0c5042d4cbb2c884497b21e76c6efb2c0bfde3a16526751",
+          "size": 166440357,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.11beta1.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.11beta1",
+          "sha256": "bf3747a0d8efff64081c9b28a0480b88e33ef21cbfb655002d2bb0f3a8d439a8",
+          "size": 165480104,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.11beta1.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.11beta1",
+          "sha256": "18d4f1f735fffa7b2cb26ef7115d4bab5f022226dfa592ce828363b23730d27d",
+          "size": 146964234,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.11beta1.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.11beta1",
+          "sha256": "a5b76161d10ede1164556c1fc745240f2bb6e36194d3142e7d98df6c2480754d",
+          "size": 167169647,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.11beta1.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.11beta1",
+          "sha256": "a6e804652f58785b3dfe272d96b8206250210e7ba7bdcb1ffb726ab3753db4af",
+          "size": 152966703,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.11beta1.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.11beta1",
+          "sha256": "df7fe096ffab5d331d35c6d038d2ec0426b45ce17f55a93037e371d3af9d4e6d",
+          "size": 169317128,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.11beta1.linux-arm64.tar.gz",
+          "os": "linux",
+          "arch": "arm64",
+          "version": "go1.11beta1",
+          "sha256": "9c1795148e777c81ac3cb381e3ea970eea60f5db2323658c061e5c4382125dd4",
+          "size": 143549189,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.11beta1.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.11beta1",
+          "sha256": "844ed9e34b118a9c2b069a18924a7879236929e08c887a92e5be1af5d701fb90",
+          "size": 143647691,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.11beta1.linux-ppc64le.tar.gz",
+          "os": "linux",
+          "arch": "ppc64le",
+          "version": "go1.11beta1",
+          "sha256": "66529a525c0369d2b79ecd19f6d16444ed162c9bf88f7b37715520841c36de65",
+          "size": 142152662,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.11beta1.linux-s390x.tar.gz",
+          "os": "linux",
+          "arch": "s390x",
+          "version": "go1.11beta1",
+          "sha256": "731b9e6ac0d4c9709297f0efc1a6455589b978d2ecc207184d3e5be07a130c9c",
+          "size": 142112213,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.11beta1.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.11beta1",
+          "sha256": "eb5d96e9c22e3df30884e292f160befb3413ffcc8a0810d444b9c20bd8015d29",
+          "size": 159864769,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.11beta1.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.11beta1",
+          "sha256": "76078abbbb6be49a41c87284ac58d2b03b6713b1fed66fce1a5a6736580b7770",
+          "size": 140828672,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.11beta1.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.11beta1",
+          "sha256": "1eeb874a919143f3e62b641ccd5ebbfd1b3d4f2184de1d6497f7b2b6df996960",
+          "size": 177305334,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.11beta1.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.11beta1",
+          "sha256": "c9ffba53b213cb52d8315ab23be2da87b6f78b633648758ed90509ef1fc22bbc",
+          "size": 155926528,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.10rc2",
+        "stable": false,
+        "files": [
+         {
+          "filename": "go1.10rc2.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.10rc2",
+          "sha256": "360bb3e627cd5308626ebe994be734da9c1c444fb420d10e79082ec110d004f6",
+          "size": 18299684,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.10rc2.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.10rc2",
+          "sha256": "0bb044de48f35a1c4845714ee049a9c0ffa1d89bd41aaaa1a034142b095c96d0",
+          "size": 117835009,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.10rc2.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.10rc2",
+          "sha256": "dfd4fecf1a3afa5f438f63a60b64c0a17346680ec2b88ed7dcabdf47d4e7ea07",
+          "size": 116926122,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.10rc2.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.10rc2",
+          "sha256": "f80526d319b19d7cf85f1f3c8a14e6be9765f35b6c586bfdf942db500e5f46c2",
+          "size": 103813077,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.10rc2.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.10rc2",
+          "sha256": "5b9b02ca787e61aabd0441795b3b10c97bc969f853496124a65697f6a50118b6",
+          "size": 115605866,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.10rc2.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.10rc2",
+          "sha256": "18832b97cdc2f21783ac60fc0136f25c19d39b7cc43459f5114dd62c0a212fe4",
+          "size": 108293682,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.10rc2.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.10rc2",
+          "sha256": "6a6a4c0654bc603bcfee4d6ac34a479c260ac61b3edcc8d6773384eb0bda512e",
+          "size": 119912109,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.10rc2.linux-arm64.tar.gz",
+          "os": "linux",
+          "arch": "arm64",
+          "version": "go1.10rc2",
+          "sha256": "dfa7fbe299b3766b94fb4bc231db4330b9860c44a57274f6a0d418bf00eccbc8",
+          "size": 102483458,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.10rc2.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.10rc2",
+          "sha256": "aa145c2a9736cbcb39b9340182c319f7fc0ab3d0f2156d7dfd722572f4da519b",
+          "size": 102998463,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.10rc2.linux-ppc64le.tar.gz",
+          "os": "linux",
+          "arch": "ppc64le",
+          "version": "go1.10rc2",
+          "sha256": "21a6e64c83df9f124993901dda2ec608640e97a13f50cf5a58f518651b576fd8",
+          "size": 101271241,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.10rc2.linux-s390x.tar.gz",
+          "os": "linux",
+          "arch": "s390x",
+          "version": "go1.10rc2",
+          "sha256": "7d3aa6ec3a761b328e093b51ca14dbb8a8000685bb8957dbab44b4bb3b1d76e7",
+          "size": 100669295,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.10rc2.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.10rc2",
+          "sha256": "479eb3a09ad72090c2b5df1bce2869ddae96bbcb8899e7564538fe92471b16ac",
+          "size": 119141491,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.10rc2.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.10rc2",
+          "sha256": "e6ad05770a1fd0905924079f615b5e8cd80901db609925e11f706683afac7ce3",
+          "size": 100241408,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.10rc2.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.10rc2",
+          "sha256": "fc0160911005b725e7f5234232a27f317b50832e3eb78382a3475ec3cac5baee",
+          "size": 131892263,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.10rc2.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.10rc2",
+          "sha256": "90120327c13d6addd6678abca7c56fb9a7ac033d8bdbe2cbcd654b2d16f096d1",
+          "size": 111656960,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.10rc1",
+        "stable": false,
+        "files": [
+         {
+          "filename": "go1.10rc1.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.10rc1",
+          "sha256": "743e97c856067f12fb39f1323d6e9956fb5f3339f0691d8749ecea553548ab03",
+          "size": 18333065,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.10rc1.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.10rc1",
+          "sha256": "6e8a585cee9cbcec8feed9eebbf310ebbde64b6bf57adab702922a03be69130c",
+          "size": 117832137,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.10rc1.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.10rc1",
+          "sha256": "62fe3046ad4a2ba1dd321ae286f1e80eede31fa9dfb176e9ccdd93aadce85e6d",
+          "size": 116967077,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.10rc1.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.10rc1",
+          "sha256": "ddfb90f94db629191539415499ecc494bab66234d24d9c1ab6bd6d6da7738d32",
+          "size": 103830119,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.10rc1.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.10rc1",
+          "sha256": "d16b8d525eb0b51c1c97ca96b42c178850ff9de72d4d3cb06625a88265a94ce9",
+          "size": 115637580,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.10rc1.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.10rc1",
+          "sha256": "03a98cc12b65dde36ed9561fa23530bcf5fa7ed85596aa74f2380f686fcbe928",
+          "size": 108299151,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.10rc1.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.10rc1",
+          "sha256": "c10d3cc7760bf3799037bd39027bbffdc568aea21d6fe60fe833373289c7b7c6",
+          "size": 119945942,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.10rc1.linux-arm64.tar.gz",
+          "os": "linux",
+          "arch": "arm64",
+          "version": "go1.10rc1",
+          "sha256": "3a749faf38e80025b832dae250442ddc86d5bc353d752c781ea632e904922ff1",
+          "size": 102500887,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.10rc1.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.10rc1",
+          "sha256": "2c1ed86e3cbf9d9866333b73cee96a0cd0b8c73654f4705088caa64eb5a624d4",
+          "size": 103004913,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.10rc1.linux-ppc64le.tar.gz",
+          "os": "linux",
+          "arch": "ppc64le",
+          "version": "go1.10rc1",
+          "sha256": "f482c7d6193c23d36657f8f026a74222c82eeb443331c38bbf3493d971144988",
+          "size": 101303051,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.10rc1.linux-s390x.tar.gz",
+          "os": "linux",
+          "arch": "s390x",
+          "version": "go1.10rc1",
+          "sha256": "a20d4077c0bb1d58710e48478ba0042950cf282f6ef1593aea4ac6e66265d22c",
+          "size": 100687431,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.10rc1.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.10rc1",
+          "sha256": "ef77802a30d051515eccf73580146fb6da33c4ebe13979af6a3af54fa821d354",
+          "size": 119155184,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.10rc1.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.10rc1",
+          "sha256": "9d53b1f54c6b3446ebed1308dc3e755efd8a290d4c7fd929d3a26a58a76e1463",
+          "size": 100257792,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.10rc1.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.10rc1",
+          "sha256": "f3730ee5ff779a2a0862e858b94b40423c613e91142be99e05e47953343326a8",
+          "size": 131913490,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.10rc1.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.10rc1",
+          "sha256": "d6e6a29f155bac2323d33d107c4cc0a5223e09280b6f942fd30dbd3970668b8d",
+          "size": 111693824,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.10beta2",
+        "stable": false,
+        "files": [
+         {
+          "filename": "go1.10beta2.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.10beta2",
+          "sha256": "a77c130eabfdea21fca629276f509b18da925912509903102b49113bc7dede9d",
+          "size": 18330416,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.10beta2.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.10beta2",
+          "sha256": "82628a1a42d7ad88b100d0c4c9c0282a7e008e4eb73876bed4bd61ac4ee11b46",
+          "size": 117629164,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.10beta2.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.10beta2",
+          "sha256": "5ee827c5ddecd9a0855feb65b7254036285e3aeefb323deeaee30dd237f05aab",
+          "size": 116749998,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.10beta2.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.10beta2",
+          "sha256": "5f712ac36c05e200a9746703e038b6b260ed95337a672ad46ea14308e7342ae4",
+          "size": 103766944,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.10beta2.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.10beta2",
+          "sha256": "15ddf22fd92093f47becf8323cf9fc24a543de7c7667b03e27bba6f29b67ae35",
+          "size": 115438254,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.10beta2.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.10beta2",
+          "sha256": "4e5bc465a828c88e0e3c6049c58ee735d8ca27a994bc1d709424425cd20cab79",
+          "size": 108239195,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.10beta2.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.10beta2",
+          "sha256": "ab3abb7d731dd5ac7a06d5d5e64ef19946f57d4ce34555d262a87b8899901a93",
+          "size": 119725410,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.10beta2.linux-arm64.tar.gz",
+          "os": "linux",
+          "arch": "arm64",
+          "version": "go1.10beta2",
+          "sha256": "2f51e94a227473d41bf3d9dbbdc5855308e64d82fb740a15019bd4fe733c9518",
+          "size": 102433906,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.10beta2.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.10beta2",
+          "sha256": "777a59c2b1516598e161c0c5b25809c83fdec3737a0b7f4942c855259d57b3fe",
+          "size": 102970707,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.10beta2.linux-ppc64le.tar.gz",
+          "os": "linux",
+          "arch": "ppc64le",
+          "version": "go1.10beta2",
+          "sha256": "ace75d03dc73351320d055535f1f314b7dbd27ab21c7878db27a385b1e00d5b0",
+          "size": 101247501,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.10beta2.linux-s390x.tar.gz",
+          "os": "linux",
+          "arch": "s390x",
+          "version": "go1.10beta2",
+          "sha256": "4d8625f071edd2cb2b16251f23530a43f9ff64db1b6ce080daff0dcc984005da",
+          "size": 100626148,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.10beta2.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.10beta2",
+          "sha256": "d8d35abda82cdf6443665beee1061cf5f4bc7e98bd19069782b4c5fea3ab56a1",
+          "size": 118923225,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.10beta2.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.10beta2",
+          "sha256": "c497c1c6b197fc0a32aad6d206d8fa8216dfe32fe4ed77b54222bc9ecb0aba7c",
+          "size": 100208640,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.10beta2.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.10beta2",
+          "sha256": "a507ec2983047e30f7595dfd6536534d98426d0423d9141749b21d772740d4c9",
+          "size": 131495430,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.10beta2.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.10beta2",
+          "sha256": "599cd45147775bfad4407db70ef609530903738722b69f48edfd7cc175a1f323",
+          "size": 111509504,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.10beta1",
+        "stable": false,
+        "files": [
+         {
+          "filename": "go1.10beta1.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.10beta1",
+          "sha256": "841df62b20fd915d83a2e43b7d043c2a3781c299de78abc45480eec575186b6b",
+          "size": 18312654,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.10beta1.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.10beta1",
+          "sha256": "8c2a4743359f4b14bcfaf27f12567e3cbfafc809ed5825a2238c0ba45db3a8b4",
+          "size": 200634773,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.10beta1.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.10beta1",
+          "sha256": "87fdf2d821be6e4d7e8578956a9f4c58a15a49aee6429e05c9716daf49be662b",
+          "size": 199317164,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.10beta1.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.10beta1",
+          "sha256": "0a40ed7d64674a96b2c2182921a1816d392eb1e924e9aeef7d698c85119eac20",
+          "size": 169992271,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.10beta1.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.10beta1",
+          "sha256": "4cacffbbbec9f2daf1c9629808adb3356c48c215c54ab9b85ebce351ae549e51",
+          "size": 194961360,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.10beta1.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.10beta1",
+          "sha256": "e0f30e18384e3beae8ce16cc6d095d899e29fb786c57297650acb7727fb3090e",
+          "size": 181739558,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.10beta1.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.10beta1",
+          "sha256": "ec7a10b5bf147a8e06cf64e27384ff3c6d065c74ebd8fdd31f572714f74a1055",
+          "size": 208138206,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.10beta1.linux-arm64.tar.gz",
+          "os": "linux",
+          "arch": "arm64",
+          "version": "go1.10beta1",
+          "sha256": "3a80555b3c4beecfb9af88c718f8676101ada74dea84f4aa1ade29d2d78554e0",
+          "size": 171225759,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.10beta1.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.10beta1",
+          "sha256": "32daa257a930ef85ca74bca107d477b3484f0b5ef7cc48086110916368d9c584",
+          "size": 122597317,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.10beta1.linux-ppc64le.tar.gz",
+          "os": "linux",
+          "arch": "ppc64le",
+          "version": "go1.10beta1",
+          "sha256": "b4c7404771b380212277fecc3b9a4f99f9978d024a45d3644c495a469df31ed8",
+          "size": 120333131,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.10beta1.linux-s390x.tar.gz",
+          "os": "linux",
+          "arch": "s390x",
+          "version": "go1.10beta1",
+          "sha256": "bc3c66ab980e782ce52165a3a1572484353904c1b884dbbb87a662776280489d",
+          "size": 139637954,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.10beta1.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.10beta1",
+          "sha256": "466b3ecca2fb2c951f48d4d64460eefc2c7ecde5505f7669fc492c6b6dccc13e",
+          "size": 176897319,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.10beta1.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.10beta1",
+          "sha256": "28e457d7c5859a278fd4d8396017428ab44d09107012886ced8959fdf33d04ad",
+          "size": 135516160,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.10beta1.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.10beta1",
+          "sha256": "ff2789b7baf33f87111d30bac81ac1ae19dcc16bdd75553f9b5aceda14733a40",
+          "size": 203132680,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.10beta1.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.10beta1",
+          "sha256": "36a341afc619ab2369d25b9bf8555ed0a9e52e72059817b6e4eda9d1527e3507",
+          "size": 149495808,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.9.2rc2",
+        "stable": false,
+        "files": [
+         {
+          "filename": "go1.9.2rc2.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.9.2rc2",
+          "sha256": "15b0c4c024c9e493ae2ec2dcacc065f904b6af70b3ed43c68aa5d3174bb42fea",
+          "size": 16383111,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.9.2rc2.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.9.2rc2",
+          "sha256": "638d45cc3f71c77242f28a920a1d188f89ece87812781bd2ce3a75092ed70c58",
+          "size": 102430669,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.9.2rc2.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.9.2rc2",
+          "sha256": "43e1c58183dbddbbf2b662259ac1bbef071b4f276294ff7a5ecf0fa34afa96cf",
+          "size": 101844149,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.9.2rc2.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.9.2rc2",
+          "sha256": "ad70267f73e3fb0a6151c4ece179ebdb676240411aba3119960f691f29400328",
+          "size": 90322436,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.9.2rc2.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.9.2rc2",
+          "sha256": "1bef0353f79a53bd9c98759f42ebd495ee26f167444b0ad486de98630c179f7f",
+          "size": 102602854,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.9.2rc2.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.9.2rc2",
+          "sha256": "3196c522f08aa482881b9479dd19e4385813280a050f83298435a1dd30500a58",
+          "size": 91913339,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.9.2rc2.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.9.2rc2",
+          "sha256": "bf28294bc9ac1fe2102a139c49b52d3947953a7aaa2cd52e6bb9772d25611faa",
+          "size": 104243864,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.9.2rc2.linux-arm64.tar.gz",
+          "os": "linux",
+          "arch": "arm64",
+          "version": "go1.9.2rc2",
+          "sha256": "eef8ae1ee126ef9d6d53fe3b3ac31b29d91dfd8d972bc808691552f0ce884507",
+          "size": 88254566,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.9.2rc2.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.9.2rc2",
+          "sha256": "0d19a6399f6fd11746feb5f322bdb9b0aff20a43b90b4727e8436ac4742f42da",
+          "size": 89665877,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.9.2rc2.linux-ppc64le.tar.gz",
+          "os": "linux",
+          "arch": "ppc64le",
+          "version": "go1.9.2rc2",
+          "sha256": "6e9a5f72399e61aac827329399afcf78fae2f9b9bce8c52b2e47340e23c6c38a",
+          "size": 87773420,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.9.2rc2.linux-s390x.tar.gz",
+          "os": "linux",
+          "arch": "s390x",
+          "version": "go1.9.2rc2",
+          "sha256": "bdf2c86e2fc8d52e7f4a81f77fb41f8c65211a921840249fbe9765b75a95a186",
+          "size": 87410276,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.9.2rc2.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.9.2rc2",
+          "sha256": "5a291730cb2b90e778a431649d98b5592393dea5d9bf9144c8048c93260a139f",
+          "size": 96456315,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.9.2rc2.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.9.2rc2",
+          "sha256": "b63dfe47d7214bccb06537cef7c8f6623df8f8e123404cbe4aeff5121fea7392",
+          "size": 82792448,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.9.2rc2.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.9.2rc2",
+          "sha256": "72efad4557c6557406d75c9f784ee03d0dea676f038338c0279c93fb5748847e",
+          "size": 109420672,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.9.2rc2.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.9.2rc2",
+          "sha256": "5a2628ca4f1f912b455661bcbf4ee29fc1529a8fc8729daa0b2ba41f57e57168",
+          "size": 94142464,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.9rc2",
+        "stable": false,
+        "files": [
+         {
+          "filename": "go1.9rc2.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.9rc2",
+          "sha256": "12b09ea6cb3189ea5e4c057f7047b5709ae8edd14706421b188f7e4ae8d8d3e4",
+          "size": 16375900,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.9rc2.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.9rc2",
+          "sha256": "18f7d7d4c85331aca3b2a8e1a92849834f1068a78b911d308a3ce1a8edab76db",
+          "size": 98096230,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.9rc2.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.9rc2",
+          "sha256": "334429bd0a84fd949632454a1e4b0709de355fc04822a90f36fbdef09f124c21",
+          "size": 97523363,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.9rc2.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.9rc2",
+          "sha256": "feaa2ca8617bc383f8d9558e0c4eb3171f87ea5e8c760f1ad60edcf9ca132aa0",
+          "size": 86011457,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.9rc2.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.9rc2",
+          "sha256": "8e8e2cab27aa4758e6c171e09694e631c60d7d88d855f2070de243a11292db88",
+          "size": 98257210,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.9rc2.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.9rc2",
+          "sha256": "b4d9e1f2f0f4f406150f21f7d166fa6f6ca54d7370752dc77e5b9f2ca2850dd0",
+          "size": 86053505,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.9rc2.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.9rc2",
+          "sha256": "0d17d440f02505d8fbf6becb777175c242486c1d71046705876dcd20e0574002",
+          "size": 98420498,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.9rc2.linux-arm64.tar.gz",
+          "os": "linux",
+          "arch": "arm64",
+          "version": "go1.9rc2",
+          "sha256": "c53bdbc41fcd980f4ad6e5f216913053709479871cd395990fa4bf4f01c21e7d",
+          "size": 83926013,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.9rc2.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.9rc2",
+          "sha256": "c61a2efe5127e88c20a49278b9748a326af197bb38949387710119914d1d77a4",
+          "size": 85345753,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.9rc2.linux-ppc64le.tar.gz",
+          "os": "linux",
+          "arch": "ppc64le",
+          "version": "go1.9rc2",
+          "sha256": "765f844aec22328d5f3347c42b22f240ad0ecb78cc6f5f55d35e47d0379cfc79",
+          "size": 83455425,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.9rc2.linux-s390x.tar.gz",
+          "os": "linux",
+          "arch": "s390x",
+          "version": "go1.9rc2",
+          "sha256": "1ec407c52ed02c472a71412733940c065666ceb76b83192c0ca09c70502b409d",
+          "size": 83093926,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.9rc2.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.9rc2",
+          "sha256": "7610058833bb57a22d3939166e43473b0de88ad6dff4bf6c8a879fdc516bb734",
+          "size": 92100032,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.9rc2.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.9rc2",
+          "sha256": "d0b6bef3a995dbd6deddf2e7d49b3deca089a2773005e1770563cf71aaa6d213",
+          "size": 78376960,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.9rc2.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.9rc2",
+          "sha256": "9bd0642fe169723732adc3300dda9b0fdf5f1ff7fab921553d2a4f482c677a3f",
+          "size": 105064359,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.9rc2.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.9rc2",
+          "sha256": "da62ebb8d921b09d03e0ffc514f0c637483c299939ff5d59bda5677970dfb72e",
+          "size": 89714688,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.9rc1",
+        "stable": false,
+        "files": [
+         {
+          "filename": "go1.9rc1.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.9rc1",
+          "sha256": "87717598ea60cc6143afa48f141f7e1308e196b71862028e710b910f376b452e",
+          "size": 16356167,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.9rc1.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.9rc1",
+          "sha256": "af5caf72379b9ce6f3c40697a6043408976694fe8cb3facc55c1cce5cc9c1fb9",
+          "size": 95445618,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.9rc1.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.9rc1",
+          "sha256": "78ea23f4c0d83357b7daf60de8f03d916f201bc58b637f479cad10cc86b577ce",
+          "size": 94860965,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.9rc1.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.9rc1",
+          "sha256": "d40d8fc89f8d47d236a890871e4c5668a752ee8f1e333a9ed82ae32a820a10ef",
+          "size": 83330621,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.9rc1.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.9rc1",
+          "sha256": "bceb9e36365c7ce6995307833d5f44157a7882cb49770398e7d8ebe1060f0bf8",
+          "size": 95607868,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.9rc1.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.9rc1",
+          "sha256": "c8bc26be65faf73289aca64c5096302962bb2b76bcadf19dfa14d0b99a8d42e0",
+          "size": 83388150,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.9rc1.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.9rc1",
+          "sha256": "a8ea2ac09878b7a5ac04fe52f144cdc64ab637230638af6975c0f1facbba3ec2",
+          "size": 95729721,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.9rc1.linux-arm64.tar.gz",
+          "os": "linux",
+          "arch": "arm64",
+          "version": "go1.9rc1",
+          "sha256": "e1d6f224b3abf6d98530f69f7a2802dfbecf696d1c8b25e3885e1f78e7e0d42b",
+          "size": 81254221,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.9rc1.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.9rc1",
+          "sha256": "634940f127ab3f60ed4acf0985ff4b3d15a9d7a9eb9547e8a112b282fc182ff9",
+          "size": 82678341,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.9rc1.linux-ppc64le.tar.gz",
+          "os": "linux",
+          "arch": "ppc64le",
+          "version": "go1.9rc1",
+          "sha256": "34c7cb9e34509fd76ef16fb58ccd88f44d14c5c8720cd2f9dcacd560d0d4caa8",
+          "size": 80784014,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.9rc1.linux-s390x.tar.gz",
+          "os": "linux",
+          "arch": "s390x",
+          "version": "go1.9rc1",
+          "sha256": "8e8a5d7b25721a5c81f4117569ffb9fce280a0dea6fff012b31403fed0e6bb2b",
+          "size": 80419631,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.9rc1.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.9rc1",
+          "sha256": "cdff7fa49f1852e3f4f78bd8c929bb2a019bc6ab75da61b62469be66eab7d5b9",
+          "size": 89408255,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.9rc1.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.9rc1",
+          "sha256": "6b4368dce39e9e09921c470b6dc0c1ae07cbaafb62e6b826a21367bb306e6411",
+          "size": 75706368,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.9rc1.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.9rc1",
+          "sha256": "936ea4b7a00f4ef2cbac02012d24940048a0a9dd5a5471e6c96d82aaf4d16e4a",
+          "size": 102371319,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.9rc1.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.9rc1",
+          "sha256": "a080a255bc2dad3813a8f061cca56608196b5a73f584e1b500cb1efed52d5786",
+          "size": 87076864,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.9beta2",
+        "stable": false,
+        "files": [
+         {
+          "filename": "go1.9beta2.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.9beta2",
+          "sha256": "4ca11b29e9c3b2ef1db837a80bc3a54a6ba392dc3f7447cb99972f9c96daa8c3",
+          "size": 16303521,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.9beta2.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.9beta2",
+          "sha256": "07e25fa6e290e46bee8ee2d836d79c3f5a35917b013ecf686d7e761631524de2",
+          "size": 94532391,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.9beta2.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.9beta2",
+          "sha256": "af7a9e81bff46d9a5e84362d285fe0827a98e5af56ef57a9aa7088693cd24489",
+          "size": 93955747,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.9beta2.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.9beta2",
+          "sha256": "27283b4b96fe9f566d53e26b4ce7db10cd4d2d5bfdd37914c19fe44e4c39bdb3",
+          "size": 82433817,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.9beta2.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.9beta2",
+          "sha256": "86cdd9759802d1b985978b4158f6e91cfae8b43a52fc99219dfc6402ee356036",
+          "size": 94696911,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.9beta2.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.9beta2",
+          "sha256": "b06f1ef695560d687c94ebd83a0c2f6d1adfa37121ddd14d361816eaa2f00d44",
+          "size": 82477295,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.9beta2.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.9beta2",
+          "sha256": "023f778f063d2234e7c95f572a92298b307807693f7e045a88c90ecd7a08f29d",
+          "size": 94833343,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.9beta2.linux-arm64.tar.gz",
+          "os": "linux",
+          "arch": "arm64",
+          "version": "go1.9beta2",
+          "sha256": "4e60b704f04441ad97b5a7c660a680225abd59b33b9044731066f2f91c18ddba",
+          "size": 80363012,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.9beta2.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.9beta2",
+          "sha256": "4be3d357c7a6ccd51c2fb89efbe32da3fa1d209f105f146429a7ea2c015e64dc",
+          "size": 81783703,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.9beta2.linux-ppc64le.tar.gz",
+          "os": "linux",
+          "arch": "ppc64le",
+          "version": "go1.9beta2",
+          "sha256": "52aad09c7b858a02d3de72ea971b656da698ef8be2647277d751b2210d9d1419",
+          "size": 79876343,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.9beta2.linux-s390x.tar.gz",
+          "os": "linux",
+          "arch": "s390x",
+          "version": "go1.9beta2",
+          "sha256": "c8166dfb2af4290acffb9382ca3a5723e8b400c718cb634614c3248740c2067f",
+          "size": 79523384,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.9beta2.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.9beta2",
+          "sha256": "d998f29e2c8a774b2ddde13a282c5b146b365b98022a1ca7a16068577036d2ba",
+          "size": 88479744,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.9beta2.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.9beta2",
+          "sha256": "527b332aa4507ffff00a4cc5689038d1ceeb22cb8324c9332640aa3f3beb58fa",
+          "size": 74809344,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.9beta2.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.9beta2",
+          "sha256": "692460aacdbfa2c36765955ede95b1c6c8b3b7afdbe8f9149947ac81e4378f2e",
+          "size": 101426986,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.9beta2.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.9beta2",
+          "sha256": "9dc9e29d1613ba0979df04df6928b7f962f1a61c17408799dad3a4e5652fe3d9",
+          "size": 86142976,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.9beta1",
+        "stable": false,
+        "files": [
+         {
+          "filename": "go1.9beta1.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.9beta1",
+          "sha256": "e42dbd2071aadb28a4d293225b04b6b4215a35a7f04417a0e47ffa38f81d642d",
+          "size": 16283705,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.9beta1.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.9beta1",
+          "sha256": "dccadebea7a5c2ca6346ba5248f7ed9cc61edac16cc43ba64a1144001c28e2eb",
+          "size": 94638982,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.9beta1.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.9beta1",
+          "sha256": "9ac9e186089e2fa123907c8642400885bb9baf49e41e0999a9f24d6805e87f8b",
+          "size": 94041766,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.9beta1.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.9beta1",
+          "sha256": "1e3d93b318684f9d6d3790ac6e6a98ccb436608a99e5907e7cc98cb85ae7242c",
+          "size": 82523757,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.9beta1.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.9beta1",
+          "sha256": "6f4ff43d5b46b98f683525255394facf4acea38409023ff655442916bbb942dc",
+          "size": 94792733,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.9beta1.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.9beta1",
+          "sha256": "af9fbef65761c03ee101eb23e1d1a673734c82b50546fed95710a6b04fe52995",
+          "size": 82556359,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.9beta1.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.9beta1",
+          "sha256": "85719a2c704ad1352052e185c760d7c65b9d8a18b491287a7e5f6775ccc27d3b",
+          "size": 94923157,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.9beta1.linux-arm64.tar.gz",
+          "os": "linux",
+          "arch": "arm64",
+          "version": "go1.9beta1",
+          "sha256": "d6877ab02d9133a51925861af2db76faabe33146ed87225450fd56c6535088ab",
+          "size": 80413887,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.9beta1.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.9beta1",
+          "sha256": "26eb517a72bd0e9b1bc7f24ea52ded1991c72e09cd876c9747641c193c734cdc",
+          "size": 81825874,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.9beta1.linux-ppc64le.tar.gz",
+          "os": "linux",
+          "arch": "ppc64le",
+          "version": "go1.9beta1",
+          "sha256": "8708e49428d493d07ce71f09b31b720ff8c8fe469698cd5e9f44f088c1ef75da",
+          "size": 79959720,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.9beta1.linux-s390x.tar.gz",
+          "os": "linux",
+          "arch": "s390x",
+          "version": "go1.9beta1",
+          "sha256": "c16f86dd69bf282ca4bba60a6449130c5c0d988917d0c1f9d62a5e2fd5191a83",
+          "size": 79607593,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.9beta1.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.9beta1",
+          "sha256": "55fb77cb2fbda60aaa038eaa4eab54acd1da1ec09ac5f285cbe4b6dea7c87eb5",
+          "size": 88559094,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.9beta1.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.9beta1",
+          "sha256": "49ef497daef1e77c3f793d811f5876e9dd67d7e998af5c0d73c4e3c236cd9a75",
+          "size": 74620928,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.9beta1.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.9beta1",
+          "sha256": "9cec41dc5825ad1f7ad8955ae4f6d0ec8ca598b3fcbf911943f5222179cb94a1",
+          "size": 101514882,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.9beta1.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.9beta1",
+          "sha256": "8689ff62697572b549f9c7156ff732bc05a9b7d6fdb2492cb171299d84a52478",
+          "size": 85946368,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.8rc3",
+        "stable": false,
+        "files": [
+         {
+          "filename": "go1.8rc3.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.8rc3",
+          "sha256": "38b1c1738f111f7bccdd372efca2aa98a7bad1ca2cb21767ba69f34ae007499c",
+          "size": 15370436,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.8rc3.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.8rc3",
+          "sha256": "6d8cec1012a7982c2fd1f013951a8dfebcaf668bc3fc0f09e582073c426bab43",
+          "size": 89601609,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.8rc3.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.8rc3",
+          "sha256": "1740ca49684ceec8aa720f4453d78885785e30e9b62e0a076518ddd6a0549cda",
+          "size": 88917666,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.8rc3.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.8rc3",
+          "sha256": "321ed21452681a06627735f4e3b4bb696b046977edbb233d47be8f21ba913916",
+          "size": 77456539,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.8rc3.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.8rc3",
+          "sha256": "cf5763d36051d5f9c5b06179af813bc38ff5dd29cd134c08f86ceaeb29575829",
+          "size": 89685956,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.8rc3.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.8rc3",
+          "sha256": "5d8aef0579a43e73d6bd557549f8ccbc3896756b8d3102a51a8cb205edfaf340",
+          "size": 77601193,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.8rc3.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.8rc3",
+          "sha256": "0ff3faba02ac83920a65b453785771e75f128fbf9ba4ad1d5e72c044103f9c7a",
+          "size": 89929547,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.8rc3.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.8rc3",
+          "sha256": "d5cd350bed748a0ef6b96701c938bc18130a9adcf9232326708bae76b66ca882",
+          "size": 76417216,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.8rc3.linux-ppc64le.tar.gz",
+          "os": "linux",
+          "arch": "ppc64le",
+          "version": "go1.8rc3",
+          "sha256": "3ec57cf9dd4d3d98ff09b5a582d623643132993c0c160f8f526cc671472bc378",
+          "size": 75731027,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.8rc3.linux-s390x.tar.gz",
+          "os": "linux",
+          "arch": "s390x",
+          "version": "go1.8rc3",
+          "sha256": "3d21666069545382c631b5aec6216af0dbbb213f406ffb3d91fd291c01e77770",
+          "size": 75181265,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.8rc3.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.8rc3",
+          "sha256": "7208620f16c779af1a4cf0cfbf64d4ecceae4a333215be090c55d79b6badb7ce",
+          "size": 83088419,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.8rc3.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.8rc3",
+          "sha256": "603fa6fac832bb79b76a8a2d8bdfb44b593a1c708aa3f3e10a899e90c1571f62",
+          "size": 69996544,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.8rc3.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.8rc3",
+          "sha256": "9ac7224a79dfd2d390ff4c5202f09fae2a5b07e9b0ebf32913979635e7143383",
+          "size": 95994887,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.8rc3.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.8rc3",
+          "sha256": "daac3d046fd376431b5d6aa07c44df84c2e112741bf2917015ddce42cb6e3e5e",
+          "size": 81338368,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.8rc2",
+        "stable": false,
+        "files": [
+         {
+          "filename": "go1.8rc2.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.8rc2",
+          "sha256": "70998e37d2f44019f78fda19b3f86a7a6a34bd0162b1d812631ebefbb306df81",
+          "size": 15365386,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.8rc2.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.8rc2",
+          "sha256": "fef703a48e0260d7c1ace71f3db7f99ff0676dc5317acc0b8d241dcb2b4e8ab7",
+          "size": 89562872,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.8rc2.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.8rc2",
+          "sha256": "4bafd09eb8191fb4a63e7f714ef347af55f4f5c91c96af611221729f7172d3cd",
+          "size": 88876705,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.8rc2.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.8rc2",
+          "sha256": "cabe48ca8e52d4903b0f760171957a3f922b49dd5ea9f8a3f34aae0df58a7d61",
+          "size": 77415423,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.8rc2.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.8rc2",
+          "sha256": "700680ad1c1d5f78e220b93c6a16d0a6f1849045799abcb6124dca2e71cc2a41",
+          "size": 89624891,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.8rc2.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.8rc2",
+          "sha256": "9ee70d9b691f07f25c8d2e969001a2f4307532af116cdc3dc9fc877bc8ac1787",
+          "size": 78926401,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.8rc2.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.8rc2",
+          "sha256": "d62c2d44d0c6b434e3cda12505f3c9fb880757e3396af1e9ba861f7b547cc864",
+          "size": 91223748,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.8rc2.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.8rc2",
+          "sha256": "a917f48329dcac21f514369746e6adf261ec806e72c880efcfded5c0dbb2b88d",
+          "size": 76396118,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.8rc2.linux-ppc64le.tar.gz",
+          "os": "linux",
+          "arch": "ppc64le",
+          "version": "go1.8rc2",
+          "sha256": "e906743ee946a026fe94ed3cf6b8e756862399f031d6072f2097d62d8f2c0638",
+          "size": 75695937,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.8rc2.linux-s390x.tar.gz",
+          "os": "linux",
+          "arch": "s390x",
+          "version": "go1.8rc2",
+          "sha256": "59649dd3d04faf38f36104eb2d0f37a2c25541e163da99d86d17916d3b2acf8d",
+          "size": 75139957,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.8rc2.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.8rc2",
+          "sha256": "7ebccec6dbd6dd91b2fe600033fa50ddbbcbf8a7a67e6daada49c9e2b52a5716",
+          "size": 83387470,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.8rc2.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.8rc2",
+          "sha256": "ea39cc0e39f981d74854c74dec532c582d1ebc7ed03453134da933249d3c6e51",
+          "size": 70242304,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.8rc2.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.8rc2",
+          "sha256": "c5eadaec783fd01bbaf8e81aef1add83a7e5c125f50f6976ac31ab763bd0b49f",
+          "size": 96304337,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.8rc2.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.8rc2",
+          "sha256": "fe8850d8837d48eb50707b5d439e5c4bafe8b6036154254d3d94fd95df2fe1f1",
+          "size": 81403904,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.8rc1",
+        "stable": false,
+        "files": [
+         {
+          "filename": "go1.8rc1.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.8rc1",
+          "sha256": "aa25758b754369018c507bbf646dda7839a41ffe4fd85a014c9704d7d8720dda",
+          "size": 15358313,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.8rc1.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.8rc1",
+          "sha256": "faf2530afbc78d8fa64054960a130f10aa2b183abd5879cdfd2ec1a4bca01ff3",
+          "size": 88764467,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.8rc1.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.8rc1",
+          "sha256": "13b76f97ca66ff2d0985aad176870a9b3987c34f84054c1bd87cfd0c641da0aa",
+          "size": 88880807,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.8rc1.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.8rc1",
+          "sha256": "b2df0f9473e66aee7a7aedd87f8b8f0c03e8e9728787fee495c9d28f804c370b",
+          "size": 77396395,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.8rc1.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.8rc1",
+          "sha256": "43eb87b65d999297d2fb5c7d2aaaa736e4ddf9775d2038842a8944102e5d3ea4",
+          "size": 89627227,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.8rc1.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.8rc1",
+          "sha256": "4f68bd330c7a18095f360abd93786092587627943af9fd920dd9927c60ccd1cf",
+          "size": 78929980,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.8rc1.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.8rc1",
+          "sha256": "bb8fe0d81161e4a8b0a8b2145ee5f8a60370baf5d48c07a83f6f09e1ad253bec",
+          "size": 91244093,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.8rc1.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.8rc1",
+          "sha256": "57369f54f1aa450344b53e8a92bcf41cd0dc2e409d28b18adfeebd0482afcb3b",
+          "size": 76388004,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.8rc1.linux-ppc64le.tar.gz",
+          "os": "linux",
+          "arch": "ppc64le",
+          "version": "go1.8rc1",
+          "sha256": "425ef7735554149bb9100a2eaaadcb97cd0414f2ec0d39122c10f0efa152f3c6",
+          "size": 75690903,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.8rc1.linux-s390x.tar.gz",
+          "os": "linux",
+          "arch": "s390x",
+          "version": "go1.8rc1",
+          "sha256": "489df221d49e6c5a5b5eae2c858be3583ce0d973ef096f27001e58fb0f589977",
+          "size": 75148000,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.8rc1.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.8rc1",
+          "sha256": "44186afc34c544f232400008c23eb7d5f163fb308c4b237bc785cb27301fdda8",
+          "size": 83379372,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.8rc1.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.8rc1",
+          "sha256": "fd1822a3ab4d98dc388dd3899f22bcb6b5dd387b98342ecab2871f694c47e31f",
+          "size": 70246400,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.8rc1.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.8rc1",
+          "sha256": "6b0fd0b5c78c6534125ea5440b2ee736cd14609e1d41eb45167ff2a37c2718c3",
+          "size": 96299240,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.8rc1.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.8rc1",
+          "sha256": "f36ed9b3df10c633099815b83ee824e083677feb466ffd0e380d73af4b1a516f",
+          "size": 81412096,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.8beta2",
+        "stable": false,
+        "files": [
+         {
+          "filename": "go1.8beta2.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.8beta2",
+          "sha256": "f5d8252f7746c77df0beb205b8f8b158362ad1718e1a2195d122ac43859f5930",
+          "size": 15324403,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.8beta2.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.8beta2",
+          "sha256": "9cfa3a7064bd201924f53458e1db500957cf2cb7bf87983eb7611e9ced153e35",
+          "size": 89306651,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.8beta2.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.8beta2",
+          "sha256": "8af39a6c765ea9b26b154efb146435053f50b79033a52d41220474800a65d967",
+          "size": 88622759,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.8beta2.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.8beta2",
+          "sha256": "23dba5a1ad82f92985f50af5cf5a85ee173dd54a00191147d44c1296862fe14e",
+          "size": 77158654,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.8beta2.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.8beta2",
+          "sha256": "21cd2adcb0c4b41df365167c8af55b83c9b853befe2211583acaac691eecd6de",
+          "size": 89389068,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.8beta2.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.8beta2",
+          "sha256": "ca3890662eb349da62ff65d79af2eb4f8995976d76b42a9d7e77c8b1ab68c72c",
+          "size": 77286399,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.8beta2.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.8beta2",
+          "sha256": "4cb9bfb0e82d665871b84070929d6eeb4d51af6bedbc8fdd3df5766e937ef84c",
+          "size": 89635382,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.8beta2.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.8beta2",
+          "sha256": "3651e280f4898eacf2a94287417e912900a18548a84388f243c6bc86bf49fd5f",
+          "size": 76162350,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.8beta2.linux-ppc64le.tar.gz",
+          "os": "linux",
+          "arch": "ppc64le",
+          "version": "go1.8beta2",
+          "sha256": "e9faff04c4ebeb1c19b7fdaaf62983250e950875086dbc5f9746eb6b5b639747",
+          "size": 75459270,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.8beta2.linux-s390x.tar.gz",
+          "os": "linux",
+          "arch": "s390x",
+          "version": "go1.8beta2",
+          "sha256": "8172ab27233d0819316a0fa449d1131cafdc57eb4d0d543a1fd635f2713805f7",
+          "size": 75056913,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.8beta2.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.8beta2",
+          "sha256": "8e35cbe184a7ef67420cdb9cdeb6785c9ab4bbf95e9e99c36ffd5119d8e72528",
+          "size": 83211951,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.8beta2.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.8beta2",
+          "sha256": "e78fa2cd8c7fceb2d89d3dc79525e4203084ab68e34b4b1d19683443298ca145",
+          "size": 70008832,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.8beta2.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.8beta2",
+          "sha256": "98e44960cdbdd9f42fb466bfd02b347a78fab9b9e48744ea86e02d9d19439ee1",
+          "size": 96114309,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.8beta2.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.8beta2",
+          "sha256": "23adb702c957f73ee5ffb35bac7587c4064a00d150edf5b477f042774e097b85",
+          "size": 81174528,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.8beta1",
+        "stable": false,
+        "files": [
+         {
+          "filename": "go1.8beta1.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.8beta1",
+          "sha256": "7204232743f85a2ebb31dbbb8ea0d792eeb89357bb2ff0ef3ed62e192fdd60e4",
+          "size": 15306317,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.8beta1.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.8beta1",
+          "sha256": "829bfc770464534ec9b217dceff7bf58c132be0967546eca649bd373b90f5a85",
+          "size": 89137637,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.8beta1.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.8beta1",
+          "sha256": "6559728476e62dd9da81e97e01886ec37c010fb95a80e4bace6e4d7a2f8451d2",
+          "size": 88463007,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.8beta1.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.8beta1",
+          "sha256": "d6bb4888aefe844ce9c23683173c9fb1e4a09b6c2ba4af4fe5d667f6df678f9f",
+          "size": 77101582,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.8beta1.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.8beta1",
+          "sha256": "081c49454bb8925ca4e7da34659be84265ac3574d8d54216da825dba4fe69a95",
+          "size": 89241883,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.8beta1.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.8beta1",
+          "sha256": "94a6fc95feb821ab165dcee8f2fa6a5ba4abad9271ba9f1e64796aa21d4bb296",
+          "size": 78601006,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.8beta1.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.8beta1",
+          "sha256": "768d8d73ccea69c9a0941f9ef2333b1ff8c82120abfcdedd4e91af039c674a8d",
+          "size": 90818333,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.8beta1.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.8beta1",
+          "sha256": "0e0c8769ee1473fd3663a089cfa287e51a651263ec30c184d33c2b96e77b5ca2",
+          "size": 76077997,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.8beta1.linux-ppc64le.tar.gz",
+          "os": "linux",
+          "arch": "ppc64le",
+          "version": "go1.8beta1",
+          "sha256": "117a36008f7a88f380f253f20f41ef8f91aa885253f57928cd63f31ee7f8acf7",
+          "size": 75375423,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.8beta1.linux-s390x.tar.gz",
+          "os": "linux",
+          "arch": "s390x",
+          "version": "go1.8beta1",
+          "sha256": "c969f6dc9d056a7c389a9fcbfdfd8096c4d170ddf816f674b018c21dffe6f2da",
+          "size": 74979361,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.8beta1.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.8beta1",
+          "sha256": "520660b7601ac1f9c4503d93b73eba8a75dfa2642414c9fb3b93810c6dd5c4e9",
+          "size": 83057481,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.8beta1.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.8beta1",
+          "sha256": "be6c549d1d81df541c7593363bb2003b8ca0bb12612e6346dc56b93bc02dccc1",
+          "size": 69955584,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.8beta1.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.8beta1",
+          "sha256": "7b246c37dfe37348a16b6bc1865ebc21a79c4fd869032fba78c65e46b11b741b",
+          "size": 95888668,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.8beta1.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.8beta1",
+          "sha256": "c45e33850f49ed6be4cad1f3eb468ee5439897f4c2ab04520c7aed10349f5c6a",
+          "size": 81051648,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.7rc6",
+        "stable": false,
+        "files": [
+         {
+          "filename": "go1.7rc6.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.7rc6",
+          "sha256": "a289943548b838c7ef606a37836d1db080a3cb3c6df4e76456e23609b8505d05",
+          "size": 14092130,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.7rc6.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.7rc6",
+          "sha256": "ffe440747f7c663d7fc276b167ac630f921e66674c9952c97eed26fea9c8ac58",
+          "size": 81466732,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7rc6.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.7rc6",
+          "sha256": "82b9b513f45506d687b7f536607d296d9be56a83153819d8b6f016b77cb21360",
+          "size": 81606282,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.7rc6.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.7rc6",
+          "sha256": "dd41e05516fa6b531757e62c6d99c2bad0d1daf8ce4eaf7bb89e74f312c64e7c",
+          "size": 71006288,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7rc6.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.7rc6",
+          "sha256": "41d94bab89817225107b480b1aac6807d098d25eac4b4adc0343702101c7ee84",
+          "size": 81666888,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7rc6.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.7rc6",
+          "sha256": "4dab8db4e80519a91188da82e99d6ea8cb82c5269eec44978c0756098e7282d0",
+          "size": 70894681,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7rc6.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.7rc6",
+          "sha256": "45e3dfba542927ea58146a5d47a983feb36401ccafeea28a9e0a79534738b154",
+          "size": 81574172,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7rc6.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.7rc6",
+          "sha256": "fc02c24601ec834c18fc2a975930d27c4abc44c65ba2999bfb0b46acbdefc09f",
+          "size": 69465206,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7rc6.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.7rc6",
+          "sha256": "7b087eb1dcc30dbc8da1d2c6591950b5e76123a98cd7cdb45a7a8f368886dd9b",
+          "size": 77423864,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7rc6.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.7rc6",
+          "sha256": "d9d451ceced47525f71829f79030ebf74cfb48680399b6d034c7506b2a127c61",
+          "size": 64274432,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.7rc6.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.7rc6",
+          "sha256": "f043f7327049340e078ded4f9eed0b811f8cfa1adb7492403d3dea9cfebee13b",
+          "size": 88282490,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7rc6.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.7rc6",
+          "sha256": "e36c1a5bd600e19e87401f495552334f862151146c54de1a9cc9e25837f88c88",
+          "size": 74559488,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.7rc5",
+        "stable": false,
+        "files": [
+         {
+          "filename": "go1.7rc5.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.7rc5",
+          "sha256": "206c90e797e66335fe134052568f63a493f27b86f765087add390d5fb4c596c4",
+          "size": 14090615,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.7rc5.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.7rc5",
+          "sha256": "d9991c5e60464f75334368fa6831484f5c577de9dadfb6e799aab43e95ef5894",
+          "size": 81434990,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7rc5.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.7rc5",
+          "sha256": "d108a207e683c13f0ad774a443ff709899f6e024955acba6b364e868a84703a7",
+          "size": 81585804,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.7rc5.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.7rc5",
+          "sha256": "ed1f6a7c8bef4a4954cd299355e9b694694fb5bdc00544e392db2d791351af0b",
+          "size": 70995333,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7rc5.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.7rc5",
+          "sha256": "5a6c4aa7242866f34dc07e7154d8666dc62cacdb5c5dc3fe7c42b880ee2aaa3f",
+          "size": 81643693,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7rc5.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.7rc5",
+          "sha256": "6d333bafb701d774b310d76e02bc8c25baee0500ed09897108b9dc24c265cc8c",
+          "size": 70885645,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7rc5.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.7rc5",
+          "sha256": "2ddf9f553aefe91d96dd3f13be55159869a221fd0111cd211dccf2cab3ee5e4a",
+          "size": 81564835,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7rc5.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.7rc5",
+          "sha256": "b6ad30af59de6bbc8499a8def5b8885f1fa6c9327ebe6afb7ead53f3c00d9af8",
+          "size": 69460577,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7rc5.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.7rc5",
+          "sha256": "9a836b38e2c2f50f50eb3b59ef69f821f7379dd52703e27ab0d7ec71f7555baa",
+          "size": 77865883,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7rc5.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.7rc5",
+          "sha256": "7c8f11b6a776a8f025196f5e594d765ef1539a219cf798f65caa81ed87bbff94",
+          "size": 64626688,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.7rc5.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.7rc5",
+          "sha256": "63878eefa637f6f337b5d9ffe07bee7547d25e7b116b694ef6c8c411ba941916",
+          "size": 88774573,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7rc5.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.7rc5",
+          "sha256": "040dd3681f93370427000237f9f89a9d0a79d8357d194fca171cf89e6aa1d397",
+          "size": 74952704,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.7rc4",
+        "stable": false,
+        "files": [
+         {
+          "filename": "go1.7rc4.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.7rc4",
+          "sha256": "f669d64cd28be4ecaa36d3a31c3060b4f6e3f801e2e37f91c3a896ce3d28f64d",
+          "size": 14089894,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.7rc4.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.7rc4",
+          "sha256": "734849ebc56eba316ec169d3749be77fc9cba7f5446179e7ff7e5a71b7c33d7e",
+          "size": 81432617,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7rc4.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.7rc4",
+          "sha256": "71a154e70be808142beb8c16a4c84343acefe2612aab3ba0540469e33f9744ab",
+          "size": 81585803,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.7rc4.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.7rc4",
+          "sha256": "4c38bbd77c3e29d567364e44f7f13fe833b6fca706a7c5c6e8e09bc35f30c6ce",
+          "size": 70995098,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7rc4.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.7rc4",
+          "sha256": "378d434372c7204d9f94d2cbe8fa9d65c8d2bea99d369805efe5412f7c19fe3f",
+          "size": 81641501,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7rc4.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.7rc4",
+          "sha256": "dbd2ff9d072f92001a4e5faad5f9b1bd0ba44d14105e3393420dd03cf15df191",
+          "size": 70881824,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7rc4.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.7rc4",
+          "sha256": "b75fa3bd2159754c404e3c83ba333d1ea80cb74de382b409afa6996abf0cc48a",
+          "size": 81566257,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7rc4.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.7rc4",
+          "sha256": "35a62136ff218d5b5fd9d0b828e27ed965f2dc5c3b302ccce93453713a70118d",
+          "size": 69457713,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7rc4.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.7rc4",
+          "sha256": "cc23ba5cee0aa8278c3f877b6246897cbd523709e952a52dad6a088afc201297",
+          "size": 77865341,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7rc4.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.7rc4",
+          "sha256": "9e3cc39865a4d8328811ce4b111034c44bb78681f07fdee945b8833d31867e0d",
+          "size": 64614400,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.7rc4.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.7rc4",
+          "sha256": "408ee195ec7f2ba1234d3c6712709a59d6daf0fd05c8c371f756b4f4f8c63bf0",
+          "size": 88773956,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7rc4.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.7rc4",
+          "sha256": "3b1b319c667a9dcda5cbf90ab488a169c9fe21a2187dda614bed5d6247be2676",
+          "size": 74964992,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.7rc3",
+        "stable": false,
+        "files": [
+         {
+          "filename": "go1.7rc3.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.7rc3",
+          "sha256": "6df6425ec3ac23fe9bcc52e1950f3a5829e5ed5a964d396d7f662a3d2fa95232",
+          "size": 14084115,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.7rc3.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.7rc3",
+          "sha256": "dce2d17ea743aefc66b2bf4f8c8d2bd4f6775dc10c7270117d928b55b3cda767",
+          "size": 81383011,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7rc3.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.7rc3",
+          "sha256": "ee5ef7b95d3c928d9967781a6ddddef5bcb1151e3f293647424113d6771f15b5",
+          "size": 81516180,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.7rc3.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.7rc3",
+          "sha256": "b463eadf76fe188bc2a362cca9b8a894eaa8109bfa68380e72210e91dcf56629",
+          "size": 70958257,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7rc3.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.7rc3",
+          "sha256": "78322bdcc446a954fc585820dbc8722fca835127d9bfefaea3f5030a738fff23",
+          "size": 81587791,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7rc3.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.7rc3",
+          "sha256": "cd1f5ac78bb921c6d84d4e05a1cf599d6f4ff507a73c15a6093de73e8fba3246",
+          "size": 70849612,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7rc3.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.7rc3",
+          "sha256": "53393c132223415c30ef877cb5c900d989f8a953e864e1119aeaedbca1918144",
+          "size": 81489638,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7rc3.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.7rc3",
+          "sha256": "998ec75795d6fb912fcec8cf5156cb998d21f64c98aa78b1b324f107ed08827b",
+          "size": 69438477,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7rc3.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.7rc3",
+          "sha256": "efa7368e384020891a1fb463943b48c1b544f65ed50fdf6bb5bf90fc99f8684a",
+          "size": 77833145,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7rc3.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.7rc3",
+          "sha256": "73edd368a14c208d5942b2b6486ef6c925c7d07fb79081a480bb0af92643dfb2",
+          "size": 64589824,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.7rc3.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.7rc3",
+          "sha256": "c179a8fcc6ca3641048125d3fea6cd19af7996da3250a985f4b9d28044cb219f",
+          "size": 88716681,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7rc3.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.7rc3",
+          "sha256": "fa09cc70fe25ae3ebbf600f67ffa7e9cc083708937c7ae78d3a444f14a11d272",
+          "size": 74919936,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.7rc2",
+        "stable": false,
+        "files": [
+         {
+          "filename": "go1.7rc2.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.7rc2",
+          "sha256": "87bafefb093dd163d264099b39b1bcdc227f54f935b77f5ff74b0d57e3638da6",
+          "size": 14081013,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.7rc2.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.7rc2",
+          "sha256": "92067f820c11db9605d0bf4f45d368351b9dea9461e162eade0faccae34cde5b",
+          "size": 81362131,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7rc2.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.7rc2",
+          "sha256": "9368418fae5f0cb8d8c2ada5ba50c1d1c253d33504c9182b79b69d1c127ed144",
+          "size": 81499789,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.7rc2.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.7rc2",
+          "sha256": "8fe7a7a48e1c0eab46a7a630073e1e0476b08cefc7f79c9b189955b6c6f408e8",
+          "size": 70926261,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7rc2.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.7rc2",
+          "sha256": "40b9a056c5f90207f517c7431f10d8a75a134a0bb4a7daa3ec25dc3ba6178ac7",
+          "size": 81545984,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7rc2.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.7rc2",
+          "sha256": "dd7b73a0b00e2b5e4fe1ee29905e03d5517c1fd5b0d1cfb774693e71347378fe",
+          "size": 70815524,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7rc2.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.7rc2",
+          "sha256": "145e486499d349757cbb7ae8dfeeea5d7a76f146f6c8880173fe3d0aacc5dd42",
+          "size": 81466596,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7rc2.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.7rc2",
+          "sha256": "425da590a02f7e34bd839ef0ef5f4f63f14996e7f5018b5d68cbf40b96e0ad20",
+          "size": 69392046,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7rc2.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.7rc2",
+          "sha256": "459a7740e26319540283f72a9381c4eaf1b7c08d87efb27accded2e8d2f20060",
+          "size": 76938189,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7rc2.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.7rc2",
+          "sha256": "f209d7b041ee6857f08d73b7e3d73737eb6c514bd25fe01750ebb4c07fddd8bf",
+          "size": 64573440,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.7rc2.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.7rc2",
+          "sha256": "fa7624b4fc96cee8633f1cc6a3d66c7b81fe5585cb3c618d6c8d08d6bc19c91c",
+          "size": 88242330,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7rc2.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.7rc2",
+          "sha256": "5c2d78f3c433b04368bec3a88b514f3b996d1b2559dba2a2473dc1e1819761bc",
+          "size": 74907648,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.7rc1",
+        "stable": false,
+        "files": [
+         {
+          "filename": "go1.7rc1.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.7rc1",
+          "sha256": "f26b42ea8d3de92efda5e2f7172b22d59e19676f23bbcf64412b32b4f4a5ff58",
+          "size": 14080593,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.7rc1.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.7rc1",
+          "sha256": "3cb26aaa589e2cbaa1e63176d1e56b1246fc79c51a0067f96415c43863436a46",
+          "size": 81360289,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7rc1.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.7rc1",
+          "sha256": "525c260321728daf80ff86c73a258ca44b4e4f902623b4f75117c3b90c4c04b9",
+          "size": 81487500,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.7rc1.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.7rc1",
+          "sha256": "78a52ffa8ebea2d02ea1eab6a343cb8d4c8524b097209c56c2c6ea7f0f9455e5",
+          "size": 70925488,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7rc1.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.7rc1",
+          "sha256": "d1323b7bff4c7abca232ac8a130390c5a85db35f8fd71b57783fc7b9c7823b23",
+          "size": 81542606,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7rc1.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.7rc1",
+          "sha256": "8b62ed1ddbceed6558b338eb88ea77c83a04f5f49fb54001007e30aa3e7c96f8",
+          "size": 70812616,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7rc1.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.7rc1",
+          "sha256": "afe956b6d323c68fbd851f4e962f26f16dde61d7caa1de1a8408c7de0b6034aa",
+          "size": 81460787,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7rc1.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.7rc1",
+          "sha256": "83000f7c50d851b34dfb75a05f72cdb988fc6d3455ec9cf0936aeab89a8d7d14",
+          "size": 69392065,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7rc1.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.7rc1",
+          "sha256": "19134ea933dc2afa6adc5ac58ec76b37e6ccf0e7e44191f28c3e0abe6e928ee2",
+          "size": 77801411,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7rc1.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.7rc1",
+          "sha256": "51b4f2adcd5bdae63b0ff5661c3d268cec102c7bb23164bb1ff36a01dc0bf188",
+          "size": 64565248,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.7rc1.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.7rc1",
+          "sha256": "bae0b350593b028a8b5e01b44a4e80774233f2390f5578c656f5a1ac152943d2",
+          "size": 88677092,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7rc1.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.7rc1",
+          "sha256": "523481f3edd4727c4ced95af625dd72597422fd97ac42839910991c1d8de9c12",
+          "size": 74915840,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.7beta2",
+        "stable": false,
+        "files": [
+         {
+          "filename": "go1.7beta2.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.7beta2",
+          "sha256": "88840e78905bdff7c8e408385182b4f77e8bdd062cac5c0c6382630588d426c7",
+          "size": 14055173,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.7beta2.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.7beta2",
+          "sha256": "d48ae10a586989fdb7e488e0bd411b461eef7d1085f1667d6a0c2a81a5e7e9ea",
+          "size": 81112909,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7beta2.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.7beta2",
+          "sha256": "3e0afb8d0d2f53a63ab98be59d9480a30fb8eb3c85c7a9f533d254e42cd3e279",
+          "size": 81249934,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.7beta2.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.7beta2",
+          "sha256": "8f89e4d53a278a29d3dd708465f04b5a8602a04196693aac3c90b9415bbae041",
+          "size": 70786636,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7beta2.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.7beta2",
+          "sha256": "7954474a74d3d42b9abbf0091945cf7177166f7e8fcb2e0e163cc0902d03d4fd",
+          "size": 81300820,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7beta2.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.7beta2",
+          "sha256": "2bed5be18e7c12d50b5513dbaf92be66715a137488d39203f3739ffe608b63a1",
+          "size": 70683340,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7beta2.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.7beta2",
+          "sha256": "688f895b51def9e065fb2610ff91afcb2b0d9637233b74130c8ca331d35d5ca5",
+          "size": 81223520,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7beta2.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.7beta2",
+          "sha256": "e6963cfea0596302184f50ff6ad4234d661bc3eeb750e01683b32088e1aa5b03",
+          "size": 69255980,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7beta2.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.7beta2",
+          "sha256": "9a69eaab3568aa2335ee1dc4fc6d52cb1f908b160a68e5144ad958633d1e5909",
+          "size": 77665005,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7beta2.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.7beta2",
+          "sha256": "1ef038ba021b3d6d6357f3fde7f93ea4316274158fb6cf148d11b588f7e63284",
+          "size": 64438272,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.7beta2.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.7beta2",
+          "sha256": "61cc2cd924f8a4de77552722bd0fe10c0f42357f811196819adf578f453084b4",
+          "size": 88422631,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7beta2.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.7beta2",
+          "sha256": "6ba747b2c9fd8e814619aa410728f8a3bbe1e37264591bb1764a87aab8fe29f8",
+          "size": 74661888,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.7beta1",
+        "stable": false,
+        "files": [
+         {
+          "filename": "go1.7beta1.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.7beta1",
+          "sha256": "a04e99ffd4139e514b91d9acec7ce11f85429a59e8552897e39fb52bcf5e1094",
+          "size": 14045129,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.7beta1.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.7beta1",
+          "sha256": "94fc763b1a618af65c186aadf019e534c164831f95c588ad452d81dd1bd4de01",
+          "size": 79442164,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7beta1.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.7beta1",
+          "sha256": "b3759ea4e63ad15839e5d107860104b9167c6fd6687f52ccaf4c649f56a70fc0",
+          "size": 79578766,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.7beta1.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.7beta1",
+          "sha256": "7925aea1c45ed986584861d3794898124dc88b94605cf824654c9bd6427ca36e",
+          "size": 69136527,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7beta1.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.7beta1",
+          "sha256": "06f1b2e66669cf8560baeff1b863eac7c1ddc246eafbcbeb3b84b0f1ba1b275f",
+          "size": 79578574,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7beta1.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.7beta1",
+          "sha256": "d794546232a433a505f90ca8f1a18ef2a0096cd6b92808f786866249540c9311",
+          "size": 69039182,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7beta1.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.7beta1",
+          "sha256": "a55e718935e2be1d5b920ed262fd06885d2d7fc4eab7722aa02c205d80532e3b",
+          "size": 79472338,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7beta1.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.7beta1",
+          "sha256": "8b8ceb9cdcf8c812130a0269b875a5dfc2aa1b2252846e0a8ddf4b68e26467eb",
+          "size": 67842788,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7beta1.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.7beta1",
+          "sha256": "d072f16716969775c94d036166005f949389a2202026c65bfb62210c699ff7b6",
+          "size": 75507912,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7beta1.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.7beta1",
+          "sha256": "1610a4dc263dea7899c3d0e51810a3684731c8307520751164f914d4bfa7a35d",
+          "size": 60313600,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.7beta1.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.7beta1",
+          "sha256": "5e12d347a9f80010a443c39e66dbb2b540ed1a9c6f174f0c65edb59bb23893ca",
+          "size": 86199556,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.7beta1.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.7beta1",
+          "sha256": "83289f5fa92f6e3f2a6c189bfec17fc9a9f7d25f90289c3bf93ee746b0252c6d",
+          "size": 70168576,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.6rc2",
+        "stable": false,
+        "files": [
+         {
+          "filename": "go1.6rc2.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.6rc2",
+          "sha256": "92914a23cde7e34e1d017175d785e5850fbb28f323a145028e2e26053ef1a598",
+          "size": 12602910,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.6rc2.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.6rc2",
+          "sha256": "e6458d5ef2245085210b0813dc91f98ba4c93319bd9be7b1baf5844fd96dab5e",
+          "size": 84646105,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.6rc2.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.6rc2",
+          "sha256": "33ce64510ea0962e86d48b80e720d4b7b6a11a1ee683b14cc8a4cee22c46558b",
+          "size": 84731537,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.6rc2.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.6rc2",
+          "sha256": "178661226760d48b99bd4d2df0b2859b5a92bc039d1e689925edf277f380f692",
+          "size": 72000533,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.6rc2.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.6rc2",
+          "sha256": "98b1b7cef91c07ce2edcc755ca7e3aefaf705cfbaa4cc8a9a8ed7a6860d9d9e8",
+          "size": 84803852,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.6rc2.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.6rc2",
+          "sha256": "e3bcdefc942883137f68230e67b69046003d5a18064bbe6c8944f3f3b3e6b6fc",
+          "size": 71961115,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.6rc2.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.6rc2",
+          "sha256": "9c19fa0fe32ee9bff79123d47147a5fd15fec451806bf5644a01173a86a8a4b9",
+          "size": 84757980,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.6rc2.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.6rc2",
+          "sha256": "cadcb5530e9a68d5ede1ab5115d985c829344eae7d04dce8e9840423536cef4f",
+          "size": 70703688,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.6rc2.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.6rc2",
+          "sha256": "7ecbd3c72a996e6d7f81a3c621beab30a25edb134048e0694cbd520e10eb104e",
+          "size": 77843859,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.6rc2.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.6rc2",
+          "sha256": "4d4ba0b54421a6a6197cb48ef15c3e64089c355864fe24a4961ce55ecd42cc16",
+          "size": 64135168,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.6rc2.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.6rc2",
+          "sha256": "0ba3ec69473a90528365ef5626b5ff892f52ab2709b0ff0a777a81f5a6f4f251",
+          "size": 91458374,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.6rc2.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.6rc2",
+          "sha256": "7b577bd9f1b08794892fd86b6c20e00df73814097435d878c15a637a51573b84",
+          "size": 74498048,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.6rc1",
+        "stable": false,
+        "files": [
+         {
+          "filename": "go1.6rc1.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.6rc1",
+          "sha256": "2d1a6756f24227dcee955add4af7d194eb4a8c3656b2c4ce778994e21a533a83",
+          "size": 12597286,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.6rc1.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.6rc1",
+          "sha256": "64e892f8a6b480050c6d95600b131dc03987c27eed91be6e7ee9931267d8dc89",
+          "size": 84636922,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.6rc1.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.6rc1",
+          "sha256": "b863db2c2a5646eaa6a1b97da711383f1a6b774090613b53d0193db7792d402a",
+          "size": 84723339,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.6rc1.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.6rc1",
+          "sha256": "46e1bdd354c65a9efc25b1f450209f9602ba82e206de9d7d3b100a180985e527",
+          "size": 71984120,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.6rc1.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.6rc1",
+          "sha256": "773b5a6cf938d723712024882041e489a921e7c8c7dc9e5d6b203e7a28a05146",
+          "size": 84783936,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.6rc1.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.6rc1",
+          "sha256": "462de63b0b84817eadf7589522a5c789f2ddb4a136a30daaa6de8459a9d1c857",
+          "size": 71949934,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.6rc1.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.6rc1",
+          "sha256": "6a8aeab9548faf933a66dafeb809bd8623c5bba1ca9626c2f28ef619b5723218",
+          "size": 84736060,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.6rc1.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.6rc1",
+          "sha256": "4340efa4836a7ddfc61d00e396e0f496a5ca5cf8bc598dc3b5f50707e6107f59",
+          "size": 70699278,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.6rc1.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.6rc1",
+          "sha256": "a745189d2e6bc79153cd368e040d998513f597e0e3a7a495844dd7d00378be8b",
+          "size": 77832913,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.6rc1.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.6rc1",
+          "sha256": "8d74ef6ff3538bd603b46fb462e6ef337dafbb793a908bd0e71290913624e186",
+          "size": 64110592,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.6rc1.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.6rc1",
+          "sha256": "30e4826e44b0875ceec415b0119e923f21fc9bdb7062ebfa8de33e8d7c1746e5",
+          "size": 91444831,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.6rc1.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.6rc1",
+          "sha256": "7591a653d59a4fdda4625df6727dda8be7907f42458ecd982eababbecf0c6e59",
+          "size": 74485760,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.6beta2",
+        "stable": false,
+        "files": [
+         {
+          "filename": "go1.6beta2.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.6beta2",
+          "sha256": "8b23d15a3edf1d154ceea5e9ca6370fc60e7f57fb1c28aa8a44c40f8f3167c6d",
+          "size": 12538927,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.6beta2.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.6beta2",
+          "sha256": "bf0a4348586a0b55df6bd99d1ee3b3a37273d0bc483a7c44169dcf13b61bc46b",
+          "size": 85740488,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.6beta2.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.6beta2",
+          "sha256": "df875fc61f6b40677eeaf160768a3c8cd74e0ae5cb6db269a008a7a584f87b1a",
+          "size": 85812882,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.6beta2.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.6beta2",
+          "sha256": "b7fa31d39f879516aac359860a0ef4127832cd63bb4394a566059faa393472bb",
+          "size": 73042092,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.6beta2.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.6beta2",
+          "sha256": "9a3149901565578f6d5a406101b0a50567c9818e631231414cc720d9184dd0d4",
+          "size": 85865241,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.6beta2.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.6beta2",
+          "sha256": "dd6a6a5ae1d130608e082d274c775819e7a3c3a9e34b982619f0281c41f25cf9",
+          "size": 73002970,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.6beta2.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.6beta2",
+          "sha256": "7ddf9797c7baaac2c16eed1a8d42f9a446223301c7dc8771ea805f211828e6a5",
+          "size": 85859620,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.6beta2.linux-armv6l.tar.gz",
+          "os": "linux",
+          "arch": "armv6l",
+          "version": "go1.6beta2",
+          "sha256": "269671775d2d4e8d929be595d9c02367962b7edb942aa344f8a8a310dd408d56",
+          "size": 71732610,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.6beta2.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.6beta2",
+          "sha256": "2ed31dbac0133d97705a71f1e42e0b40ff176ec03f8ab607b5ba71955ecc9e7d",
+          "size": 78919759,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.6beta2.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.6beta2",
+          "sha256": "3751332ccd114935acfb5b9fe8b040e637b267984fa1ce61c1e5e331299b7385",
+          "size": 65007616,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.6beta2.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.6beta2",
+          "sha256": "e4e20af2171a77c1812ddc6fa00296e73460fb92b1c89660ce2109cdfad589d6",
+          "size": 92575989,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.6beta2.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.6beta2",
+          "sha256": "a5d1e267427c67eae786a21ee6aa1d18343e2454428f815dd0de4a202c71f7a8",
+          "size": 75448320,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.6beta1",
+        "stable": false,
+        "files": [
+         {
+          "filename": "go1.6beta1.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.6beta1",
+          "sha256": "",
+          "size": 12548616,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.6beta1.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.6beta1",
+          "sha256": "",
+          "size": 85277037,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.6beta1.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.6beta1",
+          "sha256": "",
+          "size": 85345934,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.6beta1.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.6beta1",
+          "sha256": "",
+          "size": 85416863,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.6beta1.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.6beta1",
+          "sha256": "",
+          "size": 72624533,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.6beta1.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.6beta1",
+          "sha256": "",
+          "size": 85403735,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.6beta1.linux-arm6.tar.gz",
+          "os": "linux",
+          "arch": "arm6",
+          "version": "go1.6beta1",
+          "sha256": "",
+          "size": 71084795,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.6beta1.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.6beta1",
+          "sha256": "",
+          "size": 78571569,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.6beta1.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.6beta1",
+          "sha256": "",
+          "size": 64741376,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.6beta1.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.6beta1",
+          "sha256": "",
+          "size": 92150223,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.6beta1.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.6beta1",
+          "sha256": "",
+          "size": 75132928,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.5rc1",
+        "stable": false,
+        "files": [
+         {
+          "filename": "go1.5rc1.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.5rc1",
+          "sha256": "",
+          "size": 12039397,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.5rc1.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.5rc1",
+          "sha256": "",
+          "size": 77458739,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.5rc1.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.5rc1",
+          "sha256": "",
+          "size": 77772428,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.5rc1.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.5rc1",
+          "sha256": "",
+          "size": 77575892,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.5rc1.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.5rc1",
+          "sha256": "",
+          "size": 69549419,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.5rc1.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.5rc1",
+          "sha256": "",
+          "size": 77812485,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.5rc1.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.5rc1",
+          "sha256": "",
+          "size": 73477248,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.5rc1.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.5rc1",
+          "sha256": "",
+          "size": 60735488,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.5rc1.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.5rc1",
+          "sha256": "",
+          "size": 82304926,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.5rc1.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.5rc1",
+          "sha256": "",
+          "size": 67350528,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.5beta3",
+        "stable": false,
+        "files": [
+         {
+          "filename": "go1.5beta3.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.5beta3",
+          "sha256": "",
+          "size": 12062802,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.5beta3.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.5beta3",
+          "sha256": "",
+          "size": 78707331,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.5beta3.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.5beta3",
+          "sha256": "",
+          "size": 79029900,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.5beta3.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.5beta3",
+          "sha256": "",
+          "size": 78844305,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.5beta3.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.5beta3",
+          "sha256": "",
+          "size": 70737425,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.5beta3.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.5beta3",
+          "sha256": "",
+          "size": 79106503,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.5beta3.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.5beta3",
+          "sha256": "",
+          "size": 74734206,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.5beta3.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.5beta3",
+          "sha256": "",
+          "size": 61726720,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.5beta3.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.5beta3",
+          "sha256": "",
+          "size": 83650558,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.5beta3.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.5beta3",
+          "sha256": "",
+          "size": 68411392,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.5beta2",
+        "stable": false,
+        "files": [
+         {
+          "filename": "go1.5beta2.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.5beta2",
+          "sha256": "",
+          "size": 12114014,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.5beta2.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.5beta2",
+          "sha256": "",
+          "size": 0,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.5beta2.darwin-amd64.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.5beta2",
+          "sha256": "",
+          "size": 0,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.5beta2.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.5beta2",
+          "sha256": "",
+          "size": 0,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.5beta2.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.5beta2",
+          "sha256": "",
+          "size": 0,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.5beta2.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.5beta2",
+          "sha256": "",
+          "size": 0,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.5beta2.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.5beta2",
+          "sha256": "",
+          "size": 0,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.5beta2.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.5beta2",
+          "sha256": "",
+          "size": 0,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.5beta2.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.5beta2",
+          "sha256": "",
+          "size": 0,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.5beta2.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.5beta2",
+          "sha256": "",
+          "size": 0,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.5beta1",
+        "stable": false,
+        "files": [
+         {
+          "filename": "go1.5beta1.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.5beta1",
+          "sha256": "",
+          "size": 0,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.5beta1.darwin-amd64.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.5beta1",
+          "sha256": "",
+          "size": 0,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.5beta1.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.5beta1",
+          "sha256": "",
+          "size": 0,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.5beta1.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.5beta1",
+          "sha256": "",
+          "size": 0,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.5beta1.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.5beta1",
+          "sha256": "",
+          "size": 0,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.5beta1.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.5beta1",
+          "sha256": "",
+          "size": 0,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.5beta1.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.5beta1",
+          "sha256": "",
+          "size": 0,
+          "kind": "archive"
+         }
+        ]
+       },
+       {
+        "version": "go1.4rc2",
+        "stable": false,
+        "files": [
+         {
+          "filename": "go1.4rc2.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.4rc2",
+          "sha256": "",
+          "size": 0,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.4rc2.darwin-386-osx10.6.tar.gz",
+          "os": "darwin",
+          "arch": "386",
+          "version": "go1.4rc2",
+          "sha256": "",
+          "size": 0,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.4rc2.darwin-386-osx10.8.tar.gz",
+          "os": "darwin",
+          "arch": "386",
+          "version": "go1.4rc2",
+          "sha256": "",
+          "size": 0,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.4rc2.darwin-386-osx10.6.pkg",
+          "os": "darwin",
+          "arch": "386",
+          "version": "go1.4rc2",
+          "sha256": "",
+          "size": 0,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.4rc2.darwin-386-osx10.8.pkg",
+          "os": "darwin",
+          "arch": "386",
+          "version": "go1.4rc2",
+          "sha256": "",
+          "size": 0,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.4rc2.darwin-amd64-osx10.6.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.4rc2",
+          "sha256": "",
+          "size": 0,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.4rc2.darwin-amd64-osx10.8.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.4rc2",
+          "sha256": "",
+          "size": 0,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.4rc2.darwin-amd64-osx10.6.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.4rc2",
+          "sha256": "",
+          "size": 0,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.4rc2.darwin-amd64-osx10.8.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.4rc2",
+          "sha256": "",
+          "size": 0,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.4rc2.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.4rc2",
+          "sha256": "",
+          "size": 0,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.4rc2.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.4rc2",
+          "sha256": "",
+          "size": 0,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.4rc2.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.4rc2",
+          "sha256": "",
+          "size": 0,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.4rc2.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.4rc2",
+          "sha256": "",
+          "size": 0,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.4rc2.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.4rc2",
+          "sha256": "",
+          "size": 0,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.4rc2.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.4rc2",
+          "sha256": "",
+          "size": 0,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.4rc2.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.4rc2",
+          "sha256": "",
+          "size": 0,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.4rc2.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.4rc2",
+          "sha256": "",
+          "size": 0,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.4rc1",
+        "stable": false,
+        "files": [
+         {
+          "filename": "go1.4rc1.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.4rc1",
+          "sha256": "",
+          "size": 0,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.4rc1.darwin-386-osx10.6.tar.gz",
+          "os": "darwin",
+          "arch": "386",
+          "version": "go1.4rc1",
+          "sha256": "",
+          "size": 0,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.4rc1.darwin-386-osx10.8.tar.gz",
+          "os": "darwin",
+          "arch": "386",
+          "version": "go1.4rc1",
+          "sha256": "",
+          "size": 0,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.4rc1.darwin-386-osx10.6.pkg",
+          "os": "darwin",
+          "arch": "386",
+          "version": "go1.4rc1",
+          "sha256": "",
+          "size": 0,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.4rc1.darwin-386-osx10.8.pkg",
+          "os": "darwin",
+          "arch": "386",
+          "version": "go1.4rc1",
+          "sha256": "",
+          "size": 0,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.4rc1.darwin-amd64-osx10.6.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.4rc1",
+          "sha256": "",
+          "size": 0,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.4rc1.darwin-amd64-osx10.8.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.4rc1",
+          "sha256": "",
+          "size": 0,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.4rc1.darwin-amd64-osx10.6.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.4rc1",
+          "sha256": "",
+          "size": 0,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.4rc1.darwin-amd64-osx10.8.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.4rc1",
+          "sha256": "",
+          "size": 0,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.4rc1.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.4rc1",
+          "sha256": "",
+          "size": 0,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.4rc1.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.4rc1",
+          "sha256": "",
+          "size": 0,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.4rc1.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.4rc1",
+          "sha256": "",
+          "size": 0,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.4rc1.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.4rc1",
+          "sha256": "",
+          "size": 0,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.4rc1.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.4rc1",
+          "sha256": "",
+          "size": 0,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.4rc1.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.4rc1",
+          "sha256": "",
+          "size": 0,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.4rc1.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.4rc1",
+          "sha256": "",
+          "size": 0,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.4rc1.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.4rc1",
+          "sha256": "",
+          "size": 0,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.4beta1",
+        "stable": false,
+        "files": [
+         {
+          "filename": "go1.4beta1.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.4beta1",
+          "sha256": "",
+          "size": 0,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.4beta1.darwin-386-osx10.6.tar.gz",
+          "os": "darwin",
+          "arch": "386",
+          "version": "go1.4beta1",
+          "sha256": "",
+          "size": 0,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.4beta1.darwin-386-osx10.8.tar.gz",
+          "os": "darwin",
+          "arch": "386",
+          "version": "go1.4beta1",
+          "sha256": "",
+          "size": 0,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.4beta1.darwin-386-osx10.6.pkg",
+          "os": "darwin",
+          "arch": "386",
+          "version": "go1.4beta1",
+          "sha256": "",
+          "size": 0,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.4beta1.darwin-386-osx10.8.pkg",
+          "os": "darwin",
+          "arch": "386",
+          "version": "go1.4beta1",
+          "sha256": "",
+          "size": 0,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.4beta1.darwin-amd64-osx10.6.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.4beta1",
+          "sha256": "",
+          "size": 0,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.4beta1.darwin-amd64-osx10.8.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.4beta1",
+          "sha256": "",
+          "size": 0,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.4beta1.darwin-amd64-osx10.6.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.4beta1",
+          "sha256": "",
+          "size": 0,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.4beta1.darwin-amd64-osx10.8.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.4beta1",
+          "sha256": "",
+          "size": 0,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.4beta1.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.4beta1",
+          "sha256": "",
+          "size": 0,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.4beta1.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.4beta1",
+          "sha256": "",
+          "size": 0,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.4beta1.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.4beta1",
+          "sha256": "",
+          "size": 0,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.4beta1.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.4beta1",
+          "sha256": "",
+          "size": 0,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.4beta1.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.4beta1",
+          "sha256": "",
+          "size": 0,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.4beta1.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.4beta1",
+          "sha256": "",
+          "size": 0,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.4beta1.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.4beta1",
+          "sha256": "",
+          "size": 0,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.4beta1.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.4beta1",
+          "sha256": "",
+          "size": 0,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.3rc2",
+        "stable": false,
+        "files": [
+         {
+          "filename": "go1.3rc2.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.3rc2",
+          "sha256": "",
+          "size": 0,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.3rc2.darwin-386-osx10.6.tar.gz",
+          "os": "darwin",
+          "arch": "386",
+          "version": "go1.3rc2",
+          "sha256": "",
+          "size": 0,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.3rc2.darwin-386-osx10.8.tar.gz",
+          "os": "darwin",
+          "arch": "386",
+          "version": "go1.3rc2",
+          "sha256": "",
+          "size": 0,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.3rc2.darwin-386-osx10.6.pkg",
+          "os": "darwin",
+          "arch": "386",
+          "version": "go1.3rc2",
+          "sha256": "",
+          "size": 0,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.3rc2.darwin-386-osx10.8.pkg",
+          "os": "darwin",
+          "arch": "386",
+          "version": "go1.3rc2",
+          "sha256": "",
+          "size": 0,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.3rc2.darwin-amd64-osx10.6.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.3rc2",
+          "sha256": "",
+          "size": 0,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.3rc2.darwin-amd64-osx10.8.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.3rc2",
+          "sha256": "",
+          "size": 0,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.3rc2.darwin-amd64-osx10.6.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.3rc2",
+          "sha256": "",
+          "size": 0,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.3rc2.darwin-amd64-osx10.8.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.3rc2",
+          "sha256": "",
+          "size": 0,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.3rc2.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.3rc2",
+          "sha256": "",
+          "size": 0,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.3rc2.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.3rc2",
+          "sha256": "",
+          "size": 0,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.3rc2.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.3rc2",
+          "sha256": "",
+          "size": 0,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.3rc2.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.3rc2",
+          "sha256": "",
+          "size": 0,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.3rc2.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.3rc2",
+          "sha256": "",
+          "size": 0,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.3rc2.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.3rc2",
+          "sha256": "",
+          "size": 0,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.3rc2.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.3rc2",
+          "sha256": "",
+          "size": 0,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.3rc2.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.3rc2",
+          "sha256": "",
+          "size": 0,
+          "kind": "installer"
+         }
+        ]
+       },
+       {
+        "version": "go1.3rc1",
+        "stable": false,
+        "files": [
+         {
+          "filename": "go1.3rc1.src.tar.gz",
+          "os": "",
+          "arch": "",
+          "version": "go1.3rc1",
+          "sha256": "",
+          "size": 10041092,
+          "kind": "source"
+         },
+         {
+          "filename": "go1.3rc1.darwin-386-osx10.6.tar.gz",
+          "os": "darwin",
+          "arch": "386",
+          "version": "go1.3rc1",
+          "sha256": "",
+          "size": 0,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.3rc1.darwin-386-osx10.8.tar.gz",
+          "os": "darwin",
+          "arch": "386",
+          "version": "go1.3rc1",
+          "sha256": "",
+          "size": 0,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.3rc1.darwin-386-osx10.6.pkg",
+          "os": "darwin",
+          "arch": "386",
+          "version": "go1.3rc1",
+          "sha256": "",
+          "size": 0,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.3rc1.darwin-386-osx10.8.pkg",
+          "os": "darwin",
+          "arch": "386",
+          "version": "go1.3rc1",
+          "sha256": "",
+          "size": 0,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.3rc1.darwin-amd64-osx10.6.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.3rc1",
+          "sha256": "",
+          "size": 0,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.3rc1.darwin-amd64-osx10.8.tar.gz",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.3rc1",
+          "sha256": "",
+          "size": 0,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.3rc1.darwin-amd64-osx10.6.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.3rc1",
+          "sha256": "",
+          "size": 0,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.3rc1.darwin-amd64-osx10.8.pkg",
+          "os": "darwin",
+          "arch": "amd64",
+          "version": "go1.3rc1",
+          "sha256": "",
+          "size": 0,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.3rc1.freebsd-386.tar.gz",
+          "os": "freebsd",
+          "arch": "386",
+          "version": "go1.3rc1",
+          "sha256": "",
+          "size": 0,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.3rc1.freebsd-amd64.tar.gz",
+          "os": "freebsd",
+          "arch": "amd64",
+          "version": "go1.3rc1",
+          "sha256": "",
+          "size": 0,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.3rc1.linux-386.tar.gz",
+          "os": "linux",
+          "arch": "386",
+          "version": "go1.3rc1",
+          "sha256": "",
+          "size": 0,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.3rc1.linux-amd64.tar.gz",
+          "os": "linux",
+          "arch": "amd64",
+          "version": "go1.3rc1",
+          "sha256": "",
+          "size": 0,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.3rc1.windows-386.zip",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.3rc1",
+          "sha256": "",
+          "size": 0,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.3rc1.windows-386.msi",
+          "os": "windows",
+          "arch": "386",
+          "version": "go1.3rc1",
+          "sha256": "",
+          "size": 0,
+          "kind": "installer"
+         },
+         {
+          "filename": "go1.3rc1.windows-amd64.zip",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.3rc1",
+          "sha256": "",
+          "size": 0,
+          "kind": "archive"
+         },
+         {
+          "filename": "go1.3rc1.windows-amd64.msi",
+          "os": "windows",
+          "arch": "amd64",
+          "version": "go1.3rc1",
+          "sha256": "",
+          "size": 0,
+          "kind": "installer"
+         }
+        ]
        }
       ]
     headers:
@@ -16856,18 +26960,23 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Alt-Svc:
-      - h3-29=":443"; ma=2592000,h3-T051=":443"; ma=2592000,h3-Q050=":443"; ma=2592000,h3-Q046=":443";
-        ma=2592000,h3-Q043=":443"; ma=2592000,quic=":443"; ma=2592000; v="46,43"
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000,h3-T051=":443"; ma=2592000,h3-Q050=":443";
+        ma=2592000,h3-Q046=":443"; ma=2592000,h3-Q043=":443"; ma=2592000,quic=":443";
+        ma=2592000; v="46,43"
+      Cache-Control:
+      - private
       Content-Type:
       - application/json
       Date:
-      - Sat, 30 Jan 2021 23:56:34 GMT
+      - Fri, 20 Aug 2021 19:40:49 GMT
+      Server:
+      - Google Frontend
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
       Vary:
       - Accept-Encoding
-      Via:
-      - 1.1 google
+      X-Cloud-Trace-Context:
+      - 6942dfc0008e1d1ed4c61691907c623c
     status: 200 OK
     code: 200
     duration: ""


### PR DESCRIPTION
The directory go1.15.12_amedee_v1 was added causing goreleases to fail. This fixes that.